### PR TITLE
Link librt and libutil as dynamic libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ rust_compile_static = \
 	$(RUSTC) -o $(1).o --emit obj $(2); \
 	rlibs=$$($(RUSTC) -Z print-link-args $(2) \
 		| tr -s ' "' '\n' | grep rlib) \
-	&& gcc -static -static-libgcc $(1).o $$rlibs -o $(1) \
-		-lpthread -lm -ldl -lrt -lutil
+	&& gcc -Wl,-Bstatic -static-libgcc $(1).o $$rlibs -o $(1) \
+		-Wl,-Bdynamic -lpthread -lm -ldl -lrt -lutil
 
 vagga_launcher: rust-argparse/libargparse.rlib rust-quire/libquire.rlib
 vagga_launcher: libconfig.rlib libcontainer.rlib


### PR DESCRIPTION
Using dynamic system libraries will make binary more portable, and on Arch linux there're only dynamic libraries of libc by default.