### PR TITLE
Fix some warnings

### DIFF
--- a/src/builder/capsule.rs
+++ b/src/builder/capsule.rs
@@ -9,7 +9,7 @@ use std::collections::HashSet;
 use std::fs::{File};
 use std::io::{Write};
 use std::path::Path;
-use std::process::{Command, ExitStatus, Stdio};
+use std::process::{Command, Stdio};
 
 use rand::{thread_rng, Rng};
 
@@ -34,7 +34,7 @@ pub enum Feature {
 #[derive(Default)]
 pub struct State {
     capsule_base: bool,
-    alpine_ready: bool,
+    //alpine_ready: bool,
     installed_packages: HashSet<String>,
 }
 

--- a/src/builder/commands/alpine.rs
+++ b/src/builder/commands/alpine.rs
@@ -6,7 +6,7 @@ use std::process::{Command, Stdio};
 
 use super::super::super::file_util::create_dir;
 use super::super::context::{BuildContext};
-use super::super::context::Distribution::{Alpine, Unknown};
+use super::super::context::Distribution::{Alpine};
 use super::super::capsule;
 use super::super::packages;
 

--- a/src/builder/commands/debian.rs
+++ b/src/builder/commands/debian.rs
@@ -1,13 +1,12 @@
 use std::fs::{copy, rename, set_permissions, Permissions};
 use std::os::unix::fs::PermissionsExt;
 use std::fs::File;
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
-use std::string;
 
 use config::builders::UbuntuRepoInfo;
 use super::super::context::{BuildContext};
-use super::super::context::Distribution::{Ubuntu, Unknown};
+use super::super::context::Distribution::{Ubuntu};
 use super::super::download::download_file;
 use super::super::tarcmd::unpack_file;
 use super::super::packages;
@@ -30,17 +29,17 @@ pub struct UbuntuInfo {
 pub fn read_ubuntu_codename() -> Result<String, String>
 {
     let lsb_release_path = "/vagga/root/etc/lsb-release";
-    let mut lsb_release_file = BufReader::new(
+    let lsb_release_file = BufReader::new(
         try_msg!(File::open(&Path::new(lsb_release_path)),
             "Error reading /etc/lsb-release: {err}"));
 
     for line in lsb_release_file.lines() {
         let line = try_msg!(line, "Error reading lsb file: {err}");
-        if let Some(equalsPos) = line.find('=') {
-            let key = line[..equalsPos].trim();
+        if let Some(equals_pos) = line.find('=') {
+            let key = line[..equals_pos].trim();
 
             if key == "DISTRIB_CODENAME" {
-                let value = line[(equalsPos + 1)..].trim();
+                let value = line[(equals_pos + 1)..].trim();
                 return Ok(value.to_string());
             }
         }
@@ -86,7 +85,7 @@ pub fn init_ubuntu_core(ctx: &mut BuildContext) -> Result<(), String> {
 
 fn set_mirror(ctx: &mut BuildContext) -> Result<(), String> {
     let sources_list = Path::new("/vagga/root/etc/apt/sources.list");
-    let mut source = BufReader::new(try!(File::open(&sources_list)
+    let source = BufReader::new(try!(File::open(&sources_list)
         .map_err(|e| format!("Error reading sources.list file: {}", e))));
     let tmp = sources_list.with_extension("tmp");
     try!(File::create(&tmp)

--- a/src/builder/commands/generic.rs
+++ b/src/builder/commands/generic.rs
@@ -1,9 +1,7 @@
-use std::cell::RefCell;
-use std::rc::Rc;
 use std::path::{Path, PathBuf};
 
 use super::super::context::BuildContext;
-use container::monitor::{Monitor, Executor, MonitorStatus};
+use container::monitor::{Monitor};
 use container::monitor::MonitorResult::{Exit, Killed};
 use container::container::{Command};
 use container::pipe::{CPipe};
@@ -101,7 +99,7 @@ pub fn capture_command<'x>(ctx: &mut BuildContext, cmdline: &'x[String],
         cmd.set_env(k.to_string(), v.to_string());
     }
     debug!("Running {:?}", cmd);
-    let (res, data) = unsafe {
+    let (res, data) = {
         let pipe = try!(CPipe::new()
             .map_err(|e| format!("Can't create pipe: {:?}", e)));
         cmd.set_stdout_fd(pipe.writer);

--- a/src/builder/commands/npm.rs
+++ b/src/builder/commands/npm.rs
@@ -1,8 +1,6 @@
 use super::super::context::{BuildContext};
 use super::generic::{run_command, capture_command};
 use super::super::packages;
-use super::super::context::Distribution as Distr;
-use super::alpine;
 
 use std::path::Path;
 

--- a/src/builder/commands/pip.rs
+++ b/src/builder/commands/pip.rs
@@ -73,7 +73,7 @@ pub fn pip_requirements(ctx: &mut BuildContext, ver: u8, reqtxt: &Path)
 {
     let f = try!(File::open(&Path::new("/work").join(reqtxt))
         .map_err(|e| format!("Can't open requirements file: {}", e)));
-    let mut f = BufReader::new(f);
+    let f = BufReader::new(f);
     let mut names = vec!();
     for line in f.lines() {
         let line = try!(line

--- a/src/builder/context.rs
+++ b/src/builder/context.rs
@@ -1,7 +1,4 @@
-use std::fs::{create_dir_all, copy, set_permissions};
-use std::fs::Permissions;
-use std::io::Write;
-use std::os::unix::fs::PermissionsExt;
+use std::fs::{copy};
 use std::path::{Path, PathBuf};
 use std::default::Default;
 use std::collections::{BTreeMap, BTreeSet};

--- a/src/builder/download.rs
+++ b/src/builder/download.rs
@@ -2,7 +2,7 @@ use std::fs::{remove_file, rename, create_dir_all, set_permissions};
 use std::fs::{Permissions};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::{Command, ExitStatus, Stdio};
+use std::process::{Command, Stdio};
 
 use shaman::digest::Digest;
 use shaman::sha2::Sha256;

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -1,5 +1,4 @@
 use std::default::Default;
-use std::env::{set_exit_status};
 use std::path::Path;
 use std::process::exit;
 

--- a/src/builder/packages.rs
+++ b/src/builder/packages.rs
@@ -1,6 +1,5 @@
 use std::fs::copy;
 use std::path::Path;
-use std::process::{Command, ExitStatus};
 
 use super::context::Distribution as Distr;
 use super::context::BuildContext;

--- a/src/builder/tarcmd.rs
+++ b/src/builder/tarcmd.rs
@@ -1,7 +1,7 @@
-use std::fs::{create_dir_all, read_dir, set_permissions, Permissions};
+use std::fs::{create_dir_all, set_permissions, Permissions};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::{Command, ExitStatus, Stdio};
+use std::process::{Command, Stdio};
 
 use container::mount::{bind_mount, unmount};
 use config::builders::TarInfo;

--- a/src/builder/timer.rs
+++ b/src/builder/timer.rs
@@ -2,7 +2,7 @@ use std::io::Error;
 use std::io::Write;
 use std::path::Path;
 use std::fs::File;
-use std::fmt::{Debug, Arguments};
+use std::fmt::{Arguments};
 
 use container::util::{get_time, Time};
 

--- a/src/config/builders.rs
+++ b/src/config/builders.rs
@@ -1,11 +1,8 @@
-use std::fmt::{Debug, Formatter};
-use std::fmt::Error as FormatError;
 use std::path::PathBuf;
 use std::default::Default;
 use std::collections::BTreeMap;
 
 use quire::validate as V;
-use rustc_serialize::json;
 
 #[derive(RustcEncodable, RustcDecodable, Debug, Clone)]
 pub struct DebianRepo {

--- a/src/config/range.rs
+++ b/src/config/range.rs
@@ -1,9 +1,7 @@
-use std::fmt;
 use std::str::FromStr;
 
 use libc::uid_t;
 use rustc_serialize::{Decoder, Decodable};
-use quire::decode::YamlDecoder;
 
 
 #[derive(Clone, Debug, Copy)]
@@ -11,8 +9,6 @@ pub struct Range {
     start: uid_t,
     end: uid_t,
 }
-
-struct RangeError;
 
 trait StringError<T> {
     fn create_error(&self, value: String) -> T;

--- a/src/container/async.rs
+++ b/src/container/async.rs
@@ -9,7 +9,7 @@ use libc::consts::os::posix88::{SIGTERM, SIGINT, SIGQUIT};
 use time::Duration;
 
 use super::signal;
-use super::util::{Time, get_time};
+use super::util::{get_time};
 use self::Event::*;
 
 const SIGCHLD: c_int = 17;

--- a/src/container/container.rs
+++ b/src/container/container.rs
@@ -121,7 +121,7 @@ impl Command {
     }
 
     pub fn update_env<'x, I: Iterator<Item=(String, String)>>(&mut self,
-        mut env: I)
+        env: I)
     {
         for (k, v) in env {
             self.environment.insert(k, v);

--- a/src/container/monitor.rs
+++ b/src/container/monitor.rs
@@ -11,7 +11,7 @@ use super::container::Command;
 use super::signal;
 use super::signal::Signal as Sig;
 use super::util::{Time, get_time};
-use super::async::{Loop, Event};
+use super::async::{Loop};
 use super::async::Event::{Signal, Timeout, Input};
 use self::MonitorStatus::*;
 use self::MonitorResult::*;
@@ -45,6 +45,7 @@ impl Executor for RunOnce {
     }
 }
 
+/*
 impl RunOnce {
     pub fn new(cmd: Command) -> RunOnce {
         RunOnce {
@@ -52,6 +53,7 @@ impl RunOnce {
         }
     }
 }
+*/
 
 
 pub struct Process<'a> {

--- a/src/container/mount.rs
+++ b/src/container/mount.rs
@@ -136,7 +136,7 @@ pub fn get_submounts_of(dir: &Path)
 {
     let f = try!(File::open(&Path::new("/proc/self/mountinfo"))
         .map_err(|e| format!("Can't open mountinfo: {}", e)));
-    let mut buf = BufReader::new(f);
+    let buf = BufReader::new(f);
     let mut result = vec!();
     for line in buf.lines() {
         let line = try!(line

--- a/src/container/pipe.rs
+++ b/src/container/pipe.rs
@@ -4,11 +4,8 @@ use std::fs::File;
 use std::os::unix::io::{RawFd, FromRawFd};
 use nix::unistd::{pipe};
 use nix::Error::{Sys, InvalidPath};
-use nix::errno::Errno::EPIPE;
 
-use libc::{c_int, c_void};
-use libc::funcs::posix88::unistd::{close, write};
-use libc::consts::os::posix88::{EINTR, EAGAIN};
+use libc::funcs::posix88::unistd::{close};
 
 
 pub struct CPipe {
@@ -29,16 +26,14 @@ impl CPipe {
     pub fn read(self) -> Result<Vec<u8>, IoError> {
         let mut buf = Vec::new();
         unsafe {
-          let CPipe {reader, writer} = self;
-          close(writer);
+          close(self.writer);
           try!(File::from_raw_fd(self.reader).read_to_end(&mut buf));
         }
         Ok(buf)
     }
     pub fn wakeup(self) -> Result<(), IoError> {
         unsafe {
-          let CPipe {reader, writer} = self;
-          close(reader);
+          close(self.reader);
           File::from_raw_fd(self.writer).write_all(b"x")
         }
     }

--- a/src/container/signal.rs
+++ b/src/container/signal.rs
@@ -34,9 +34,9 @@ pub fn block_all() {
 
 fn _convert_status(status: i32) -> i32 {
     if status & 0xff == 0 {
-        return ((status & 0xff00) >> 8);
+        return (status & 0xff00) >> 8;
     }
-    return (128 + (status & 0x7f));  // signal
+    return 128 + (status & 0x7f);  // signal
 }
 
 pub fn check_children() -> Option<Signal> {

--- a/src/container/uidmap.rs
+++ b/src/container/uidmap.rs
@@ -1,5 +1,4 @@
 use std::cmp::min;
-use std::cmp::Ordering;
 use std::env;
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, BufRead, Write};
@@ -29,7 +28,7 @@ fn read_uid_map(username: &str) -> Result<Vec<Range>,String> {
     let file = try_msg!(File::open(&Path::new("/etc/subuid")),
         "Can't open /etc/subuid: {err}");
     let mut res = Vec::new();
-    let mut reader = BufReader::new(file);
+    let reader = BufReader::new(file);
     for (num, line) in reader.lines().enumerate() {
         let line = try_msg!(line, "Error reading /etc/subuid: {err}");
         let parts: Vec<&str> = line[..].split(':').collect();
@@ -51,7 +50,7 @@ fn read_gid_map(username: &str) -> Result<Vec<Range>,String> {
     let file = try_msg!(File::open(&Path::new("/etc/subgid")),
         "Can't open /etc/subgid: {err}");
     let mut res = Vec::new();
-    let mut reader = BufReader::new(file);
+    let reader = BufReader::new(file);
     for (num, line) in reader.lines().enumerate() {
         let line = try_msg!(line, "Error reading /etc/subgid: {err}");
         let parts: Vec<&str> = line[..].split(':').collect();
@@ -269,12 +268,12 @@ pub fn apply_uidmap(pid: pid_t, map: &Uidmap) -> Result<(), IoError> {
 
 fn read_uid_ranges(path: &str, read_inside: bool) -> Result<Vec<Range>, String>
 {
-    let mut file = BufReader::new(try!(File::open(&Path::new(path))
+    let file = BufReader::new(try!(File::open(&Path::new(path))
         .map_err(|e| format!("Error reading uid/gid map: {}", e))));
     let mut result = vec!();
     for line in file.lines() {
         let line = try!(line
-            .map_err(|e| format!("Error reading uid/gid map")));
+            .map_err(|_| format!("Error reading uid/gid map")));
         let mut words = line[..].split_whitespace();
         let inside: u32 = try!(words.next().and_then(|x| FromStr::from_str(x).ok())
             .ok_or(format!("uid/gid map format error")));

--- a/src/container/util.rs
+++ b/src/container/util.rs
@@ -1,13 +1,11 @@
 use std::ffi::CStr;
 use std::fs::{read_dir, remove_dir_all, remove_file, remove_dir, copy};
 use std::fs::{symlink_metadata, read_link};
-use std::fs::{FileType};
-use std::os::unix::fs::{symlink, DirEntryExt, MetadataExt};
+use std::os::unix::fs::{symlink, MetadataExt};
 use std::ptr::null;
 use std::path::Path;
 
 use libc::{c_int, uid_t, gid_t, c_char, c_void, timeval};
-use libc::chmod;
 
 use super::root::temporary_change_root;
 use file_util::create_dir_mode;

--- a/src/container/vagga.rs
+++ b/src/container/vagga.rs
@@ -1,5 +1,4 @@
 use std::fs::read_link;
-use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 
 

--- a/src/launcher/build.rs
+++ b/src/launcher/build.rs
@@ -11,7 +11,7 @@ pub fn build_container(config: &Config, name: &String) -> Result<(), String> {
     build_command(config, vec!(name.clone())).map(|_| ())
 }
 
-pub fn build_command(config: &Config, mut args: Vec<String>)
+pub fn build_command(config: &Config, args: Vec<String>)
     -> Result<i32, String>
 {
     let mut name: String = "".to_string();

--- a/src/launcher/mod.rs
+++ b/src/launcher/mod.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::io::{stderr, Write};
-use std::path::{Path, PathBuf};
+use std::path::{Path};
 use std::process::exit;
 
 use config::find_config;

--- a/src/launcher/network.rs
+++ b/src/launcher/network.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::fs::{remove_file};
 use std::fs::{File};
 use std::io::{stdout, stderr, BufRead, BufReader, Read};
-use std::os::unix::io::{RawFd, FromRawFd};
+use std::os::unix::io::{FromRawFd};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::rc::Rc;
@@ -11,10 +11,9 @@ use std::collections::HashSet;
 
 use rand::thread_rng;
 use rand::distributions::{Range, IndependentSample};
-use libc::{pid_t};
 use libc::{geteuid};
 use argparse::{ArgumentParser};
-use argparse::{StoreTrue, StoreFalse, List, StoreOption, Store};
+use argparse::{StoreTrue, StoreFalse};
 use rustc_serialize::json;
 
 use super::super::config::Config;
@@ -25,8 +24,7 @@ use super::super::container::container::Namespace::{NewUser, NewNet};
 use super::super::container::container::Command as ContainerCommand;
 use shaman::sha2::Sha256;
 use shaman::digest::Digest;
-use super::user;
-use file_util::{create_dir, create_dir_mode};
+use file_util::{create_dir_mode};
 use path_util::{PathExt};
 
 static MAX_INTERFACES: u32 = 2048;
@@ -463,7 +461,7 @@ pub fn join_gateway_namespaces() -> Result<(), String> {
 pub fn get_nameservers() -> Result<Vec<String>, String> {
     File::open(&Path::new("/etc/resolv.conf"))
         .map(BufReader::new)
-        .and_then(|mut f| {
+        .and_then(|f| {
             let mut ns = vec!();
             for line in f.lines() {
                 let line = try!(line);
@@ -479,7 +477,7 @@ pub fn get_nameservers() -> Result<Vec<String>, String> {
 fn get_interfaces() -> Result<HashSet<u32>, String> {
     File::open(&Path::new("/proc/net/dev"))
         .map(BufReader::new)
-        .and_then(|mut f| {
+        .and_then(|f| {
             let mut lineiter = f.lines();
             let mut result = HashSet::with_capacity(MAX_INTERFACES as usize);
             try!(lineiter.next().unwrap());  // Two header lines

--- a/src/launcher/supervisor.rs
+++ b/src/launcher/supervisor.rs
@@ -20,7 +20,7 @@ use config::command::SuperviseMode::{stop_on_failure};
 use config::command::ChildCommand::{BridgeCommand};
 
 use super::network;
-use super::user::{run_wrapper, common_child_command_env};
+use super::user::{common_child_command_env};
 use super::build::build_container;
 use file_util::create_dir;
 use path_util::PathExt;

--- a/src/launcher/underscore.rs
+++ b/src/launcher/underscore.rs
@@ -1,14 +1,11 @@
 use std::io::{stdout, stderr};
 use std::path::Path;
 
-use libc::pid_t;
-
 use argparse::{ArgumentParser};
-use argparse::{StoreTrue, StoreFalse, List, StoreOption, Store};
+use argparse::{StoreTrue, List, StoreOption, Store};
 
 use config::Config;
-use config::command::{CommandInfo, Networking};
-use container::container::Namespace::{NewUser, NewNet};
+use container::container::Namespace::{NewNet};
 use container::nsutil::{set_namespace};
 
 use super::user;

--- a/src/network/graphs.rs
+++ b/src/network/graphs.rs
@@ -1,6 +1,5 @@
 use std::env;
 use std::io::{stdout, stderr};
-use std::mem::swap;
 use std::collections::{HashSet, HashMap};
 
 use argparse::{ArgumentParser, List};

--- a/src/network/iptables.rs
+++ b/src/network/iptables.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 use std::path::Path;
-use std::process::{Command, ExitStatus, Stdio};
+use std::process::{Command, Stdio};
 
 use super::graphs::{Graph, NodeLinks};
 use super::graphs::NodeLinks::{Full, Isolate, DropSome};

--- a/src/network/run.rs
+++ b/src/network/run.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::io::{stdout, stderr};
 use std::path::Path;
-use std::process::{Command, ExitStatus, Stdio};
+use std::process::{Command, Stdio};
 
 use argparse::{ArgumentParser, Store, List};
 

--- a/src/path_util.rs
+++ b/src/path_util.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 use std::os::unix::ffi::OsStrExt;
-use std::path::{Path, PathBuf, Components};
+use std::path::{Path, PathBuf};
 use std::path::Component::RootDir;
 use std::fs::metadata;
 

--- a/src/setup_netns/mod.rs
+++ b/src/setup_netns/mod.rs
@@ -14,7 +14,7 @@ use argparse::{ArgumentParser, Store, List};
 fn has_interface(name: &str) -> Result<bool, String> {
     File::open(&Path::new("/proc/net/dev"))
         .map(BufReader::new)
-        .and_then(|mut f| {
+        .and_then(|f| {
             let mut lineiter = f.lines();
             try!(lineiter.next().unwrap());  // Two header lines
             try!(lineiter.next().unwrap());
@@ -69,10 +69,9 @@ fn setup_gateway_namespace(args: Vec<String>) {
                 "Gateway address");
         match ap.parse(args, &mut stdout(), &mut stderr()) {
             Ok(()) => {}
-            Err(0) => return,
+            Err(0) => {}
             Err(x) => {
                 exit(x);
-                return;
             }
         }
     }
@@ -83,7 +82,6 @@ fn setup_gateway_namespace(args: Vec<String>) {
             Err(x) => {
                 error!("Error setting interface vagga_guest: {}", x);
                 exit(1);
-                return;
             }
         }
         sleep_ms(100);
@@ -124,7 +122,6 @@ fn setup_gateway_namespace(args: Vec<String>) {
             err => {
                 error!("Error running command {:?}: {:?}", cmd, err);
                 exit(1);
-                return;
             }
         };
     }
@@ -158,10 +155,9 @@ fn setup_bridge_namespace(args: Vec<String>) {
             .required();
         match ap.parse(args, &mut stdout(), &mut stderr()) {
             Ok(()) => {}
-            Err(0) => return,
+            Err(0) => {}
             Err(x) => {
                 exit(x);
-                return;
             }
         }
     }
@@ -174,7 +170,6 @@ fn setup_bridge_namespace(args: Vec<String>) {
             Err(x) => {
                 error!("Error setting interface {}: {}", interface, x);
                 exit(1);
-                return;
             }
         }
         sleep_ms(100);
@@ -233,7 +228,6 @@ fn setup_bridge_namespace(args: Vec<String>) {
             err => {
                 error!("Error running command {:?}: {:?}", cmd, err);
                 exit(1);
-                return;
             }
         };
     }
@@ -267,10 +261,9 @@ fn setup_guest_namespace(args: Vec<String>) {
             .required();
         match ap.parse(args, &mut stdout(), &mut stderr()) {
             Ok(()) => {}
-            Err(0) => return,
+            Err(0) => {}
             Err(x) => {
                 exit(x);
-                return;
             }
         }
     }
@@ -281,7 +274,6 @@ fn setup_guest_namespace(args: Vec<String>) {
             Err(x) => {
                 error!("Error setting interface {}: {}", interface, x);
                 exit(1);
-                return;
             }
         }
         sleep_ms(100);
@@ -316,7 +308,6 @@ fn setup_guest_namespace(args: Vec<String>) {
             err => {
                 error!("Error running command {:?}: {:?}", cmd, err);
                 exit(1);
-                return;
             }
         };
     }

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -2,7 +2,7 @@ use std::default::Default;
 use std::fs::File;
 use std::path::Path;
 use std::process::exit;
-use std::io::{stdout, Read, Write};
+use std::io::{Read, Write};
 use std::os::unix::io::FromRawFd;
 
 use nix::unistd::dup2;
@@ -88,8 +88,8 @@ pub fn run() -> i32 {
 
 pub fn main() {
     // let's make stdout safer
-    unsafe { dup2(1, 3) };
-    unsafe { dup2(2, 1) };
+    dup2(1, 3);
+    dup2(2, 1);
 
     let val = run();
     exit(val);

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -10,7 +10,6 @@ use config::read_config;
 use config::builders::{Builder};
 use config::builders::Builder as B;
 use config::builders::Source as S;
-use shaman::sha2::Sha256;
 use shaman::digest::Digest;
 use container::vagga::container_ver;
 use self::HashResult::*;
@@ -36,7 +35,7 @@ impl VersionHash for Builder {
                 match
                     File::open(&Path::new("/work").join(fname))
                     .and_then(|f| {
-                        let mut f = BufReader::new(f);
+                        let f = BufReader::new(f);
                         for line in f.lines() {
                             let line = try!(line);
                             let chunk = line[..].trim();

--- a/src/wrapper/build.rs
+++ b/src/wrapper/build.rs
@@ -1,15 +1,13 @@
 use std::env;
 use std::rc::Rc;
 use std::cell::RefCell;
-use std::fs::{remove_dir_all, create_dir_all, rename};
+use std::fs::{remove_dir_all, rename};
 use std::fs::{remove_file, remove_dir};
 use std::io::{stdout, stderr};
 use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 
 use argparse::{ArgumentParser, Store, StoreTrue};
-use nix::unistd::close;
-use nix::unistd::pipe;
 use rustc_serialize::json;
 
 use container::mount::{bind_mount, unmount};

--- a/src/wrapper/clean.rs
+++ b/src/wrapper/clean.rs
@@ -4,7 +4,6 @@ use std::io::{stdout, stderr};
 use std::path::Path;
 use std::str::FromStr;
 
-use libc::pid_t;
 use argparse::{ArgumentParser, PushConst, StoreTrue};
 
 use super::setup;

--- a/src/wrapper/commandline.rs
+++ b/src/wrapper/commandline.rs
@@ -16,7 +16,6 @@ use container::monitor::MonitorResult::{Killed, Exit};
 use container::container::{Command};
 use container::vagga::container_ver;
 
-use super::build;
 use super::setup;
 use super::Wrapper;
 use super::util::find_cmd;

--- a/src/wrapper/run.rs
+++ b/src/wrapper/run.rs
@@ -8,14 +8,12 @@ use libc::pid_t;
 
 use argparse::{ArgumentParser, Store, List, StoreTrue};
 
-use config::{Container};
-use container::uidmap::{map_users, Uidmap};
+use container::uidmap::{map_users};
 use container::monitor::{Monitor};
 use container::monitor::MonitorResult::{Killed, Exit};
 use container::container::{Command};
 use container::vagga::container_ver;
 
-use super::build;
 use super::setup;
 use super::Wrapper;
 use path_util::PathExt;

--- a/src/wrapper/setup.rs
+++ b/src/wrapper/setup.rs
@@ -2,11 +2,9 @@ use std::collections::BTreeMap;
 use std::env;
 use std::env::{current_exe};
 use std::io::{BufRead, BufReader, ErrorKind};
-use std::ffi::CString;
 use std::fs::{copy, read_link, hard_link, set_permissions, Permissions};
 use std::fs::{remove_dir_all, read_dir, symlink_metadata};
 use std::fs::File;
-use std::fs::FileType;
 use std::os::unix::fs::{symlink, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
@@ -266,7 +264,7 @@ pub fn get_environment(container: &Container)
         }
     }
     if let Some(ref filename) = container.environ_file {
-        let mut f = BufReader::new(try!(
+        let f = BufReader::new(try!(
                 File::open(filename)
                 .map_err(|e| format!("Error reading environment file {}: {}",
                     filename.display(), e))));


### PR DESCRIPTION
Mostly unused imports and unused mut.

@tailhook This one looks like a bug https://github.com/tailhook/vagga/blob/master/src/container/async.rs#L82 

```
src/container/async.rs:81:35: 81:43 warning: unused variable: `duration`, #[warn(unused_variables)] on by default
src/container/async.rs:81     pub fn add_timeout(&mut self, duration: Duration, name: Name) {
```
