### PR TITLE
Fix prefix variable in install.sh script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 DESTDIR=${DESTDIR:-}
-PREFIX=${DESTDIR:-/usr}
+PREFIX=${PREFIX:-/usr}
 
 install -d ${DESTDIR}${PREFIX}/bin
 install -d ${DESTDIR}${PREFIX}/lib/vagga


### PR DESCRIPTION
Now prefix equals to DESTDIR which brakes the build.