### PR TITLE
Example with PostgreSQL+Alembic added

### DIFF
--- a/examples/postgres-alembic/alembic.ini
+++ b/examples/postgres-alembic/alembic.ini
@@ -1,0 +1,39 @@
+[alembic]
+script_location = alembic
+# sqlalchemy.url is set in env.py from environment variable
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/examples/postgres-alembic/alembic/env.py
+++ b/examples/postgres-alembic/alembic/env.py
@@ -1,0 +1,58 @@
+from __future__ import with_statement
+import os
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from logging.config import fileConfig
+
+config = context.config
+fileConfig(config.config_file_name)
+target_metadata = None
+
+config.set_main_option('sqlalchemy.url', os.environ.get('DATABASE_URL'))
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix='sqlalchemy.',
+        poolclass=pool.NullPool)
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/examples/postgres-alembic/alembic/script.py.mako
+++ b/examples/postgres-alembic/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/examples/postgres-alembic/alembic/versions/360aff35f0d_init.py
+++ b/examples/postgres-alembic/alembic/versions/360aff35f0d_init.py
@@ -1,0 +1,28 @@
+"""init
+
+Revision ID: 360aff35f0d
+Revises: 
+Create Date: 2015-10-30 15:24:23.181676
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '360aff35f0d'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('tbl',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('name', sa.String(length=256), nullable=False),
+    sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade():
+    op.drop_table('tbl')

--- a/examples/postgres-alembic/app.py
+++ b/examples/postgres-alembic/app.py
@@ -1,0 +1,14 @@
+import os
+from flask import Flask
+from flask.ext.sqlalchemy import SQLAlchemy
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL')
+db = SQLAlchemy(app)
+
+@app.route('/')
+def hello_world():
+    return '; '.join(db.engine.table_names())
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0')

--- a/examples/postgres-alembic/vagga.yaml
+++ b/examples/postgres-alembic/vagga.yaml
@@ -1,0 +1,56 @@
+#
+# Running instance with PostgreSQL and application required alembic migration.
+# Example shows usage of locks using filesystem: alembic requires to wait until
+# database is set up fully before run.
+#
+
+containers:
+  python:
+    setup:
+    - !Ubuntu trusty
+    - !Install [libpq-dev]
+    - !PipConfig {dependencies: true}
+    - !Py3Install [Flask-SQLAlchemy, alembic, psycopg2]
+    environ:
+      DATABASE_URL: postgresql://vagga:vagga@127.0.0.1:5433/test
+
+  postgres:
+    setup:
+    - !Ubuntu trusty
+    - !Install [postgresql]
+    - !EnsureDir /data
+    environ:
+      PG_PORT: 5433
+      PG_DB: test
+      PG_USER: vagga
+      PG_PASSWORD: vagga
+      PGDATA: /data
+      PG_BIN: /usr/lib/postgresql/9.3/bin
+    volumes:
+      /data: !Tmpfs
+        size: 100M
+        mode: 0o700
+
+commands:
+  run: !Supervise
+    description: Run app
+    children:
+      service: !Command
+        container: python
+        run: |
+            touch /work/.dbcreation # Create lock file
+            while [ -f /work/.dbcreation ]; do sleep 0.2; done # Acquire lock
+            alembic upgrade head
+            python3 app.py
+
+      db: !Command
+        container: postgres
+        run: |
+            chown postgres:postgres $PGDATA;
+            su postgres -c "$PG_BIN/pg_ctl initdb";
+            su postgres -c "echo 'host all all all trust' >> $PGDATA/pg_hba.conf"
+            su postgres -c "$PG_BIN/pg_ctl -w -o '-F --port=$PG_PORT -k /tmp' start";
+            su postgres -c "$PG_BIN/psql -h 127.0.0.1 -p $PG_PORT -c \"CREATE USER $PG_USER WITH PASSWORD '$PG_PASSWORD';\""
+            su postgres -c "$PG_BIN/createdb -h 127.0.0.1 -p $PG_PORT $PG_DB -O $PG_USER";
+            rm /work/.dbcreation # Release lock
+            sleep infinity


### PR DESCRIPTION
Using the case of application using alembic migrations, this example shows how to perform synchronization between containers using filesystem.

Here, container with app waits until database sets up and runs migration after that.

Not sure if there's neater way to do it.