### PR TITLE
Examples for firefox #126

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -29,6 +29,7 @@ Miscellaneous
 
    examples/misc/travis
    examples/misc/selenium
+   examples/misc/firefox
 
 
 Documentation

--- a/docs/examples/misc/firefox.rst
+++ b/docs/examples/misc/firefox.rst
@@ -1,0 +1,45 @@
+===============
+Firefox Browser
+===============
+
+To run firefox, or any other GUI application, there are some extra steps
+involved to setup a display.
+
+The ``/tmp/.X11-unix/`` director should be mounted in the container. This
+can be accomplished by making it available to vagga under the name ``X11``
+by writing the following lines in your global configuration ``~/.vagga.yaml``::
+
+    external-volumes:
+      X11: /tmp/.X11-unix/
+
+Next, you can use the following ``vagga.yaml`` file to setup the actual 
+configuration. 
+
+.. literalinclude:: ../../../examples/firefox/vagga.yaml
+   :language: yaml
+
+When calling vagga, remember to export the ``DISPLAY`` 
+environment variable and set the ``HOME`` to be ``/tmp``  to allow firefox 
+a place to write the user profile::
+
+    vagga -eDISPLAY -EHOME=/tmp firefox
+
+WebGL Support
+-------------
+
+To enable webgl support further steps are necessary to install the 
+drivers inside the container, and that ultimately depends on your video card
+model.
+
+To setup the proprietary nvidia drivers, download the driver from the 
+`NVIDIA website <http://www.nvidia.ca/Download/index.aspx?lang=en-us>`_ and
+use the following ``vagga.yaml``:
+
+.. literalinclude:: ../../../examples/firefox/vagga_webgl_nvidia.yaml
+   :language: yaml
+ 
+For intel videocards use the following ``vagga.yaml`` (this includes also 
+chromium and java plugins):
+
+.. literalinclude:: ../../../examples/firefox/vagga_webgl_intel.yaml
+   :language: yaml

--- a/docs/examples/misc/firefox.rst
+++ b/docs/examples/misc/firefox.rst
@@ -24,6 +24,12 @@ a place to write the user profile::
 
     vagga -eDISPLAY -EHOME=/tmp firefox
 
+To prevent DBUS-related errors also export the ``DBUS_SESSION_BUS_ADDRESS``
+environmental variable::
+
+   vagga -eDISPLAY -EHOME=/tmp -eDBUS_SESSION_BUS_ADDRESS firefox
+
+
 WebGL Support
 -------------
 

--- a/docs/examples/misc/firefox.rst
+++ b/docs/examples/misc/firefox.rst
@@ -13,21 +13,21 @@ by writing the following lines in your global configuration ``~/.vagga.yaml``::
       X11: /tmp/.X11-unix/
 
 Next, you can use the following ``vagga.yaml`` file to setup the actual 
-configuration. 
+configuration (we redefine the variable ``HOME`` because firefox needs to 
+write profile information).
 
 .. literalinclude:: ../../../examples/firefox/vagga.yaml
    :language: yaml
 
 When calling vagga, remember to export the ``DISPLAY`` 
-environment variable and set the ``HOME`` to be ``/tmp``  to allow firefox 
-a place to write the user profile::
+environment variable::
 
-    vagga -eDISPLAY -EHOME=/tmp firefox
+    vagga -eDISPLAY firefox
 
 To prevent DBUS-related errors also export the ``DBUS_SESSION_BUS_ADDRESS``
 environmental variable::
 
-   vagga -eDISPLAY -EHOME=/tmp -eDBUS_SESSION_BUS_ADDRESS firefox
+   vagga -eDISPLAY -eDBUS_SESSION_BUS_ADDRESS firefox
 
 
 WebGL Support

--- a/docs/examples/misc/firefox.rst
+++ b/docs/examples/misc/firefox.rst
@@ -2,10 +2,10 @@
 Firefox Browser
 ===============
 
-To run firefox, or any other GUI application, there are some extra steps
+To run firefox or any other GUI application there are some extra steps
 involved to setup a display.
 
-The ``/tmp/.X11-unix/`` director should be mounted in the container. This
+The ``/tmp/.X11-unix/`` directory should be mounted in the container. This
 can be accomplished by making it available to vagga under the name ``X11``
 by writing the following lines in your global configuration ``~/.vagga.yaml``::
 
@@ -34,18 +34,17 @@ WebGL Support
 -------------
 
 To enable webgl support further steps are necessary to install the 
-drivers inside the container, and that ultimately depends on your video card
-model.
+drivers inside the container, that depends on your video card model.
 
 To setup the proprietary nvidia drivers, download the driver from the 
-`NVIDIA website <http://www.nvidia.ca/Download/index.aspx?lang=en-us>`_ and
-use the following ``vagga.yaml``:
+`NVIDIA website <http://www.nvidia.ca/Download/index.aspx?lang=en-us>`_ in the 
+your working directory and use the following ``vagga.yaml``:
 
 .. literalinclude:: ../../../examples/firefox/vagga_webgl_nvidia.yaml
    :language: yaml
  
-For intel videocards use the following ``vagga.yaml`` (this includes also 
-chromium and java plugins):
+For intel video cards use the following ``vagga.yaml`` (this includes also 
+chromium and java plugin):
 
 .. literalinclude:: ../../../examples/firefox/vagga_webgl_intel.yaml
    :language: yaml

--- a/examples/firefox/vagga.yaml
+++ b/examples/firefox/vagga.yaml
@@ -15,4 +15,5 @@ containers:
 commands:
   firefox: !Command
     container: browser
+    environ: { HOME: /tmp }
     run: [firefox]

--- a/examples/firefox/vagga.yaml
+++ b/examples/firefox/vagga.yaml
@@ -1,0 +1,18 @@
+containers:
+  browser:
+    setup:
+    - !Ubuntu trusty
+    - !UbuntuUniverse
+    - !Install [firefox]
+    volumes:
+      /tmp: !Tmpfs
+        size: 100Mi
+        mode: 0o1777
+        subdirs:
+          .X11-unix:
+      /tmp/.X11-unix: !BindRW /volumes/X11
+
+commands:
+  firefox: !Command
+    container: browser
+    run: [firefox]

--- a/examples/firefox/vagga_webgl_intel.yaml
+++ b/examples/firefox/vagga_webgl_intel.yaml
@@ -19,4 +19,5 @@ containers:
 commands:
   firefox: !Command
     container: browser
+    environ: { HOME: /tmp }
     run: [firefox]

--- a/examples/firefox/vagga_webgl_intel.yaml
+++ b/examples/firefox/vagga_webgl_intel.yaml
@@ -1,0 +1,22 @@
+containers:
+  browser:
+    setup:
+    - !Ubuntu trusty
+    - !UbuntuUniverse
+    - !Install [chromium-browser]
+    - !Install [firefox, icedtea-plugin]
+    - !Install [xserver-xorg-video-intel, mesa-utils, libgl1-mesa-dri]
+    - !EnsureDir /root
+    volumes:
+      /tmp: !Tmpfs
+        size: 100Mi
+        mode: 0o1777
+        subdirs:
+          .X11-unix:
+      /tmp/.X11-unix: !BindRW /volumes/X11
+      /root: !BindRW /work/home
+
+commands:
+  firefox: !Command
+    container: browser
+    run: [firefox]

--- a/examples/firefox/vagga_webgl_nvidia.yaml
+++ b/examples/firefox/vagga_webgl_nvidia.yaml
@@ -1,0 +1,21 @@
+containers:
+  browser:
+    setup:
+    - !Ubuntu trusty
+    - !UbuntuUniverse
+    - !Install [binutils, pkg-config, mesa-utils]
+    - !Sh sh /work/NVIDIA-Linux-x86_64-331.67.run -a -N --ui=none --no-kernel-module
+    - !Sh nvidia-xconfig -a --use-display-device=None --enable-all-gpus --virtual=1280x1024
+    - !Install [firefox]
+    volumes:
+      /tmp: !Tmpfs
+        size: 100Mi
+        mode: 0o1777
+        subdirs:
+          .X11-unix:
+      /tmp/.X11-unix: !BindRW /volumes/X11
+
+commands:
+  firefox: !Command
+    container: browser
+    run: [firefox]

--- a/examples/firefox/vagga_webgl_nvidia.yaml
+++ b/examples/firefox/vagga_webgl_nvidia.yaml
@@ -18,4 +18,5 @@ containers:
 commands:
   firefox: !Command
     container: browser
+    environ: { HOME: /tmp }
     run: [firefox]


### PR DESCRIPTION
There are three examples. Simple firefox, and installation of graphics driver for intel and nvidia cards. (issue #126 )