### PR TITLE
Added support for different Ubuntu architectures.

### DIFF
--- a/docs/build_steps.rst
+++ b/docs/build_steps.rst
@@ -63,6 +63,9 @@ Ubuntu Commands
      The verison of ubuntu to install. This must be digital ``YY.MM`` form,
      not a code name. **Required**.
 
+   arch
+     The architecture to install. Defaults to ``amd64``.
+
    keep-chfn-command
      (default ``false``) This may be set to ``true`` to enable
      ``/usr/bin/chfn`` command in the container. This often doesn't work on

--- a/src/builder/commands/ubuntu.rs
+++ b/src/builder/commands/ubuntu.rs
@@ -30,6 +30,7 @@ pub enum Version {
 pub struct Ubuntu {
     version: Version,
     codename: Option<String>,
+    arch: String,
     apt_update: bool,
     has_universe: bool,
     clobber_chfn: bool,
@@ -42,7 +43,7 @@ impl Named for Ubuntu {
 impl Distribution for Ubuntu {
     fn name(&self) -> &'static str { "Ubuntu" }
     fn bootstrap(&mut self, ctx: &mut Context) -> Result<(), StepError> {
-        try!(fetch_ubuntu_core(ctx, &self.version));
+        try!(fetch_ubuntu_core(ctx, &self.version, self.arch.clone()));
         let codename = try!(read_ubuntu_codename());
         if self.codename.is_some() && self.codename.as_ref() != Some(&codename) {
             return Err(From::from("Codename mismatch. \
@@ -290,12 +291,11 @@ pub fn read_ubuntu_codename() -> Result<String, String>
                 lsb_release_path=lsb_release_path))
 }
 
-pub fn fetch_ubuntu_core(ctx: &mut Context, ver: &Version)
+pub fn fetch_ubuntu_core(ctx: &mut Context, ver: &Version, arch: String)
     -> Result<(), String>
 {
     let url_base = "http://cdimage.ubuntu.com/ubuntu";
     let kind = "core";
-    let arch = "amd64";
     let url = match *ver {
         Version::Daily { ref codename } => {
             format!(
@@ -421,6 +421,7 @@ pub fn configure(guard: &mut Guard, info: &UbuntuReleaseInfo)
 {
     try!(guard.distro.set(Ubuntu {
         version: Version::Release { version: info.version.clone() },
+        arch: info.arch.clone(),
         codename: None, // unknown yet
         apt_update: true,
         has_universe: false,
@@ -451,6 +452,7 @@ pub fn configure_simple(guard: &mut Guard, codename: &str)
 {
     try!(guard.distro.set(Ubuntu {
         version: Version::Daily { codename: codename.to_string() },
+        arch: "amd64".to_string(),
         codename: Some(codename.to_string()),
         clobber_chfn: true,
         apt_update: true,

--- a/src/config/builders.rs
+++ b/src/config/builders.rs
@@ -66,6 +66,7 @@ pub struct FileInfo {
 #[derive(RustcEncodable, RustcDecodable, Debug, Clone)]
 pub struct UbuntuReleaseInfo {
     pub version: String,
+    pub arch: String,
     pub keep_chfn_command: bool,
 }
 
@@ -268,6 +269,7 @@ pub fn builder_validator<'x>() -> V::Enum<'x> {
     .option("Ubuntu", V::Scalar::new())
     .option("UbuntuRelease", V::Structure::new()
         .member("version", V::Scalar::new())
+        .member("arch", V::Scalar::new().default("amd64"))
         .member("keep_chfn_command", V::Scalar::new().default(false)))
     .option("UbuntuRepo", V::Structure::new()
         .member("url", V::Scalar::new())

--- a/tests/ubuntu.bats
+++ b/tests/ubuntu.bats
@@ -8,6 +8,12 @@ setup() {
     [[ $link = ".roots/trusty.52f1f091/root" ]]
 }
 
+@test "Ubuntu i386 builds" {
+    vagga _build trusty-i386
+    link=$(readlink .vagga/trusty-i386)
+    [[ $link = ".roots/trusty-i386.a2ec035d/root" ]]
+}
+
 @test "Run echo command" {
     run vagga echo-cmd hello
     printf "%s\n" "${lines[@]}"
@@ -46,6 +52,13 @@ setup() {
     printf "%s\n" "${lines[@]}"
     [[ $status -eq 121 ]]
     [[ $output =~ "Command test not found." ]]
+}
+
+@test "Check arch support" {
+    run vagga check-arch
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ $output = i386 ]]
 }
 
 @test "Run trusty bc" {

--- a/tests/ubuntu/vagga.yaml
+++ b/tests/ubuntu/vagga.yaml
@@ -4,6 +4,12 @@ containers:
     setup:
     - !Ubuntu trusty
 
+  trusty-i386:
+    setup:
+    - !UbuntuRelease
+      version: 14.04.4
+      arch: i386
+
   trusty-calc:
     setup:
     - !Ubuntu trusty
@@ -41,6 +47,10 @@ commands:
     container: trusty
     accepts-arguments: true
     run: echo "$@"
+
+  check-arch: !Command
+    container: trusty-i386
+    run: dpkg --print-architecture
 
   trusty-calc: !Command
     container: trusty-calc


### PR DESCRIPTION
I'm a total Rust newbie, so I hope I've used the proper idioms. 

I've tested it with UbuntuRelease (with and without the "arch" option) and with plain "Ubuntu", and it seems to work as expected.

I haven't found how to build the docs, though, but I guess it'll be OK.