### PR TITLE
Add `tags` field to Command and allow filtering processes by tags

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -67,6 +67,33 @@ Parameters of `!Command`
 
    The container to run command in
 
+.. opt:: tags
+
+   The list of tags for this command.
+   Tags are used for processes filtering (with ``--only`` and ``--exclude``)
+   when running any ``!Supervise`` command.
+
+   Simple example:
+
+   .. code-block:: yaml
+
+      commands:
+        run: !Supervise
+          children:
+            postgres: !Command
+              tags: [service]
+              run: ...
+            redis: !Command
+              tags: [service]
+              run: ...
+            app: !Command
+              tags: [app]
+              run: ...
+
+   .. code-block:: bash
+
+      vagga run --only service  # will start only postgres and redis processes
+
 .. opt:: run
 
    The command to run. It can be:

--- a/src/config/command.rs
+++ b/src/config/command.rs
@@ -47,6 +47,7 @@ pub struct CommandInfo {
     pub banner: Option<String>,
     pub banner_delay: Option<u32>,
     pub epilog: Option<String>,
+    pub tags: Vec<String>,
 
     // Command
     pub network: Option<Network>, // Only for top-levels
@@ -103,6 +104,12 @@ impl ChildCommand {
             ChildCommand::BridgeCommand(ref info) => &info.container,
         }
     }
+    pub fn get_tags<'x>(&'x self) -> &Vec<String> {
+        match *self {
+            ChildCommand::Command(ref info) => &info.tags,
+            ChildCommand::BridgeCommand(ref info) => &info.tags,
+        }
+    }
 }
 
 fn shell_command(ast: Ast) -> Vec<Ast> {
@@ -155,6 +162,7 @@ fn command_fields<'a>(cmd: V::Structure) -> V::Structure {
     .member("banner", V::Scalar::new().optional())
     .member("banner_delay", V::Numeric::new().optional().min(0))
     .member("epilog", V::Scalar::new().optional())
+    .member("tags", V::Sequence::new(V::Scalar::new()))
 }
 
 fn subcommand_validator<'a>() -> V::Enum<'a> {

--- a/src/launcher/completion.rs
+++ b/src/launcher/completion.rs
@@ -305,8 +305,13 @@ impl<'a> CompletionState<'a> {
                 States::SuperviseOptionArg(cmd_name, opt) => {
                     if let Some(&MainCommand::Supervise(ref cmd_info)) = self.commands.get(cmd_name) {
                         if opt.accept_children {
-                            if cmd_info.children.contains_key(arg) {
-                                self.supervise_chosen_children.insert(arg);
+                            for (name, child) in cmd_info.children.iter() {
+                                if name == arg {
+                                    self.supervise_chosen_children.insert(arg);
+                                }
+                                if child.get_tags().iter().any(|t| t == arg) {
+                                    self.supervise_chosen_children.insert(arg);
+                                }
                             }
                         }
                     }
@@ -445,10 +450,16 @@ impl<'a> CompletionState<'a> {
         let mut completions = Vec::new();
         if let Some(&MainCommand::Supervise(ref cmd_info)) = self.commands.get(cmd_name) {
             if opt.accept_children {
-                for child in cmd_info.children.keys() {
-                    let child_name = &child[..];
+                for (name, child) in cmd_info.children.iter() {
+                    let child_name = &name[..];
                     if !self.supervise_chosen_children.contains(child_name) {
                         completions.push(child_name);
+                    }
+                    for tag in child.get_tags().iter() {
+                        let tag = &tag[..];
+                        if !self.supervise_chosen_children.contains(tag) {
+                            completions.push(tag);
+                        }
                     }
                 }
             }

--- a/tests/generic.bats
+++ b/tests/generic.bats
@@ -79,6 +79,45 @@ setup() {
     [[ ${lines[${#lines[@]}-2]} = "world" ]]
 }
 
+@test "generic: The supervice --only with tags" {
+    run vagga tagged --only first_and_third
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/busybox)
+    [[ $link = ".roots/busybox.f87ff413/root" ]]
+    [[ ${lines[${#lines[@]}-3]} = "hello" ]]
+    [[ ${lines[${#lines[@]}-2]} = ":)" ]]
+
+    run vagga tagged --only first_and_second
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/busybox)
+    [[ $link = ".roots/busybox.f87ff413/root" ]]
+    [[ ${lines[${#lines[@]}-3]} = "hello" ]]
+    [[ ${lines[${#lines[@]}-2]} = "world" ]]
+
+    run vagga tagged --only third_only
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/busybox)
+    [[ $link = ".roots/busybox.f87ff413/root" ]]
+    [[ ${lines[${#lines[@]}-2]} = ":)" ]]
+}
+
+@test "generic: The supervice --only mixed" {
+    run vagga tagged --only first first_and_second
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/busybox)
+    [[ $link = ".roots/busybox.f87ff413/root" ]]
+    [[ ${lines[${#lines[@]}-3]} = "hello" ]]
+    [[ ${lines[${#lines[@]}-2]} = "world" ]]
+
+    run vagga tagged --only third first_and_second
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/busybox)
+    [[ $link = ".roots/busybox.f87ff413/root" ]]
+    [[ ${lines[${#lines[@]}-4]} = "hello" ]]
+    [[ ${lines[${#lines[@]}-3]} = "world" ]]
+    [[ ${lines[${#lines[@]}-2]} = ":)" ]]
+}
+
 @test "generic: The supervise --exclude" {
     run vagga two-lines --exclude second-line
     printf "%s\n" "${lines[@]}"
@@ -87,6 +126,41 @@ setup() {
     [[ ${lines[${#lines[@]}-2]} = "hello" ]]
 
     run vagga two-lines --exclude first-line
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/busybox)
+    [[ $link = ".roots/busybox.f87ff413/root" ]]
+    [[ ${lines[${#lines[@]}-2]} = "world" ]]
+}
+
+@test "generic: The supervice --exclude with tags" {
+    run vagga tagged --exclude first_and_third
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/busybox)
+    [[ $link = ".roots/busybox.f87ff413/root" ]]
+    [[ ${lines[${#lines[@]}-2]} = "world" ]]
+
+    run vagga tagged --exclude first_and_second
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/busybox)
+    [[ $link = ".roots/busybox.f87ff413/root" ]]
+    [[ ${lines[${#lines[@]}-2]} = ":)" ]]
+
+    run vagga tagged --exclude third_only
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/busybox)
+    [[ $link = ".roots/busybox.f87ff413/root" ]]
+    [[ ${lines[${#lines[@]}-3]} = "hello" ]]
+    [[ ${lines[${#lines[@]}-2]} = "world" ]]
+}
+
+@test "generic: The supervice --exclude mixed" {
+    run vagga tagged --exclude first first_and_second
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/busybox)
+    [[ $link = ".roots/busybox.f87ff413/root" ]]
+    [[ ${lines[${#lines[@]}-2]} = ":)" ]]
+
+    run vagga tagged --exclude first_and_third third_only
     printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/busybox)
     [[ $link = ".roots/busybox.f87ff413/root" ]]

--- a/tests/generic/vagga.yaml
+++ b/tests/generic/vagga.yaml
@@ -69,6 +69,29 @@ commands:
           echo hello
           sleep 0.1
 
+  tagged: !Supervise
+    children:
+      first: !Command
+        container: busybox
+        tags: [first_and_second, first_and_third]
+        run: |
+          echo hello
+          sleep 0.2
+      second: !Command
+        container: busybox
+        tags: [first_and_second]
+        run: |
+          sleep 0.05
+          echo world
+          sleep 0.15
+      third: !Command
+        container: busybox
+        tags: [first_and_third, third_only]
+        run: |
+          sleep 0.1
+          echo ":)"
+          sleep 0.1
+
   one-kills-another: !Supervise
     children:
       dying: !Command


### PR DESCRIPTION
This allow marking some commands in supervise block with common tag and then running only those
by filtering on that tag:
```yaml
commands:
  run: !Supervise
    children:
      db: !Command
        tags: [db, service]
      redis-master: !Command
        tags: [db, service]
      redis-slave: !Command
        tags: [db, service]
      nginx: !Command
        tags: [service]
      frontend_app: !Command
        tags: [app]
      backend_app: !Command
        tags: [app]
      tasks_queue: !Command
        tags: [app]
```
and then runn all "services" with:
`vagga run --only-tags service`
instead of:
`vagga run --only db redis-master redis-slave nginx` or
`vagga run --exclude frontend_app backend_app tasks_queue`

**no tests yet**