### PR TITLE
PHP/Composer fixes

### DIFF
--- a/docs/build_steps.rst
+++ b/docs/build_steps.rst
@@ -1151,12 +1151,12 @@ PHP/Composer Commands
    Install a list of php packages using ``composer global require --prefer-dist
    --update-no-dev``. Packages are installed in ``/usr/local/lib/composer/vendor``.
 
-   Binaries are automatically symlinked to ``/usr/local/bin`` by Composer so
+   Binaries are automatically installed to ``/usr/local/bin`` by Composer so
    they are available in your PATH.
 
-   Composer itself is located at ``/tmp/composer.phar`` and symlinked to
-   ``/usr/local/bin/composer``. After container is built, Composer is no longer
-   available.
+   Composer itself is located at ``/usr/local/bin/composer`` and available in
+   your PATH as well. After container is built, the Composer executable is no
+   longer available.
 
 .. step:: ComposerDependencies
 

--- a/src/builder/commands/alpine.rs
+++ b/src/builder/commands/alpine.rs
@@ -214,7 +214,8 @@ fn system_deps(pkg: packages::Package) -> Option<Vec<&'static str>> {
         packages::Npm => Some(vec!("nodejs")),  // Need duplicate?
         // PHP
         packages::Php => Some(vec!(
-            "php", "php-cli", "php-openssl", "php-phar", "php-json", "php-pdo", "php-dom"
+            "php", "php-cli", "php-openssl", "php-phar",
+            "php-json", "php-pdo", "php-dom", "php-zip"
         )),
         packages::PhpDev => Some(vec!()),
         packages::Composer => None,

--- a/src/builder/commands/composer.rs
+++ b/src/builder/commands/composer.rs
@@ -65,7 +65,7 @@ fn composer_cmd(ctx: &mut Context) -> Result<Command, StepError> {
         .clone()
         .unwrap_or(DEFAULT_RUNTIME.to_owned());
     let mut cmd = try!(command(ctx, runtime));
-    cmd.arg("/tmp/composer.phar");
+    cmd.arg("/usr/local/bin/composer");
     cmd.arg("--no-interaction");
     Ok(cmd)
 }
@@ -152,12 +152,10 @@ pub fn bootstrap(ctx: &mut Context) -> Result<(), String> {
     let args = [
         runtime_exe,
         "/tmp/composer-setup.php".to_owned(),
-        "--install-dir=/tmp/".to_owned(),
+        "--install-dir=/usr/local/bin/".to_owned(),
+        "--filename=composer".to_owned(),
     ];
     try!(run_command(ctx, &args));
-
-    try_msg!(unix_fs::symlink("/vagga/root/tmp/composer.phar", "/vagga/root/usr/local/bin/composer"),
-        "Error creating symlink '/usr/local/bin/composer -> /tmp/composer.phar': {err}");
 
     if ctx.composer_settings.install_runtime {
         try!(setup_include_path(ctx));
@@ -253,7 +251,7 @@ fn ask_php_for_conf_d(ctx: &mut Context) -> Result<PathBuf, String> {
 pub fn finish(ctx: &mut Context) -> Result<(), StepError> {
     try!(list_packages(ctx));
     try!(fs::remove_file(Path::new("/vagga/root/usr/local/bin/composer"))
-        .map_err(|e| format!("Error removing symlink '/usr/local/bin/composer': {}", e)));
+        .map_err(|e| format!("Error removing '/usr/local/bin/composer': {}", e)));
 
     Ok(())
 }

--- a/src/builder/commands/composer.rs
+++ b/src/builder/commands/composer.rs
@@ -1,7 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::fs::{self, File};
 use std::io::Write;
-use std::os::unix::fs as unix_fs;
 
 use unshare::{Command};
 use scan_dir::{self, ScanDir};

--- a/tests/composer.bats
+++ b/tests/composer.bats
@@ -7,6 +7,17 @@ teardown() {
     if [ -f composer.lock ]; then rm composer.lock; fi
 }
 
+# test composer is available in PATH and removed after container is built
+@test "composer: lifecycle" {
+    run vagga _build composer-lifecycle
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ $output = *"Composer version"* ]]
+    [[ ! -f ".vagga/composer-lifecycle/usr/local/bin/composer" ]]
+    link=$(readlink .vagga/composer-lifecycle)
+    [[ $link = ".roots/composer-lifecycle.1de6d854/root" ]]
+}
+
 # php
 
 @test "composer: php ubuntu trusty" {

--- a/tests/composer/vagga.yaml
+++ b/tests/composer/vagga.yaml
@@ -1,4 +1,11 @@
 containers:
+  # test composer is available in PATH and removed after container is built
+  composer-lifecycle:
+    setup:
+    - !Alpine v3.3
+    - !ComposerInstall
+    - !Sh composer --version
+
   # php
   php-ubuntu-trusty:
     setup:


### PR DESCRIPTION
This fixes two problems in php/composer integration:

The first one is that the symlink to the composer executable `/usr/local/bin/composer -> /tmp/composer.phar` wasn't working, calling `composer` always returned "command not found". Now, composer is installed directly to `/usr/local/bin` and removed after container is built.

The second one that the module `php-zip` was not installed by default in Alpine. This is not really a fix, but a convenience for some popular tools, like the laravel installer, that requires this module.