### PR TITLE
Update to Rust 1.8 and other build dependencies

### DIFF
--- a/vagga.yaml
+++ b/vagga.yaml
@@ -20,26 +20,26 @@ containers:
     # Build script derived from
     # https://github.com/rust-lang/rust-buildbot/blob/master/slaves/linux/build-musl.sh
     - !TarInstall
-      url: http://www.musl-libc.org/releases/musl-1.1.11.tar.gz
+      url: http://www.musl-libc.org/releases/musl-1.1.14.tar.gz
       script: |
         ./configure --prefix=/musl --disable-shared
         make -j2
         make install
 
     - !Tar
-      url: http://llvm.org/releases/3.7.0/llvm-3.7.0.src.tar.xz
+      url: http://llvm.org/releases/3.8.0/llvm-3.8.0.src.tar.xz
       path: /tmp/llvm
     - !TarInstall
-      url: http://llvm.org/releases/3.7.0/libunwind-3.7.0.src.tar.xz
+      url: http://llvm.org/releases/3.8.0/libunwind-3.8.0.src.tar.xz
       script: |
-        cmake . -DLLVM_PATH=/tmp/llvm/llvm-3.7.0.src -DLIBUNWIND_ENABLE_SHARED=0
+        cmake . -DLLVM_PATH=/tmp/llvm/llvm-3.8.0.src -DLIBUNWIND_ENABLE_SHARED=0
         make -j2
         cp lib/libunwind.a /musl/lib
     - !TarInstall
-      url: "http://static.rust-lang.org/dist/rust-1.7.0-x86_64-unknown-linux-gnu.tar.gz"
+      url: "http://static.rust-lang.org/dist/rust-1.8.0-x86_64-unknown-linux-gnu.tar.gz"
       script: "./install.sh --prefix=/usr --components=rustc,rust-std-x86_64-unknown-linux-gnu,cargo"
     - !TarInstall
-      url: "http://static.rust-lang.org/dist/rust-std-1.7.0-x86_64-unknown-linux-musl.tar.gz"
+      url: "http://static.rust-lang.org/dist/rust-std-1.8.0-x86_64-unknown-linux-musl.tar.gz"
       script: "./install.sh --prefix=/musl \
                --components=rust-std-x86_64-unknown-linux-musl"
     - !Sh 'ln -s /musl/lib/rustlib/x86_64-unknown-linux-musl /usr/lib/rustlib/x86_64-unknown-linux-musl'


### PR DESCRIPTION
Rust 1.8 has been released, this is updating to Rust 1.8(from 1.7), LLVM 3.8(3.7) and Musl 1.1.14(1.1.11).

I would of moved the `!Install`s all into 1 single one so this gets a little bit faster but I feel like it was intentionally sacrificed a little so that it is more clear which packages are for what.
I ran `make test` with this binary but didn't wait for them all since it takes a long time(and I was getting low on space).

Reminder: You are getting close to 1000 commits!