### PR TITLE
Add --no-remote to firefox doc example, switch to xenial and other minor doc fixes

### DIFF
--- a/docs/build_steps.rst
+++ b/docs/build_steps.rst
@@ -243,25 +243,25 @@ Generic Commands
        - !Ubuntu trusty
        - !Cmd ["apt-get", "install", "-y", "python"]
 
-    You may use YAMLy features to get complex things. To run complex python
-    code you may use::
+   You may use YAMLy features to get complex things. To run complex python
+   code you may use::
 
-        setup:
-        - !Cmd
-          - python
-          - -c
-          - |
-            import socket
-            print("Builder host", socket.gethostname())
+       setup:
+       - !Cmd
+         - python
+         - -c
+         - |
+           import socket
+           print("Builder host", socket.gethostname())
 
-    Or to get behavior similar to :step:`Sh` command, but with different shell:
+   Or to get behavior similar to :step:`Sh` command, but with different shell::
 
-        setup:
-        - !Cmd
-          - /bin/bash
-          - -exc
-          - |
-            echo this is a bash script
+       setup:
+       - !Cmd
+         - /bin/bash
+         - -exc
+         - |
+           echo this is a bash script
 
 .. step:: Download
 

--- a/docs/examples/misc/firefox.rst
+++ b/docs/examples/misc/firefox.rst
@@ -7,10 +7,12 @@ involved to setup a display.
 
 The ``/tmp/.X11-unix/`` directory should be mounted in the container. This
 can be accomplished by making it available to vagga under the name ``X11``
-by writing the following lines in your global configuration ``~/.vagga.yaml``::
+by writing the following lines in your `global configuration`_ ``~/.vagga.yaml``::
 
     external-volumes:
       X11: /tmp/.X11-unix/
+
+.. _global configuration: ../../settings.html#global-settings
 
 Next, you can use the following ``vagga.yaml`` file to setup the actual 
 configuration (we redefine the variable ``HOME`` because firefox needs to 
@@ -18,6 +20,14 @@ write profile information).
 
 .. literalinclude:: ../../../examples/firefox/vagga.yaml
    :language: yaml
+
+.. note::
+   If Firefox is already running on your host system, it will
+   connect to it to avoid creating another instance and it
+   will use the resources of your host system instead of the container's.
+
+   We pass ``--no-remote`` to tell it to create a new instance
+   inside the container, to avoid exposing the host file system.
 
 When calling vagga, remember to export the ``DISPLAY`` 
 environment variable::
@@ -33,7 +43,7 @@ environmental variable::
 WebGL Support
 -------------
 
-To enable webgl support further steps are necessary to install the 
+To enable WebGL support further steps are necessary to install the
 drivers inside the container, that depends on your video card model.
 
 To setup the proprietary nvidia drivers, download the driver from the 

--- a/examples/firefox/vagga.yaml
+++ b/examples/firefox/vagga.yaml
@@ -1,7 +1,7 @@
 containers:
   browser:
     setup:
-    - !Ubuntu trusty
+    - !Ubuntu xenial
     - !UbuntuUniverse
     - !Install [firefox]
     volumes:
@@ -16,4 +16,4 @@ commands:
   firefox: !Command
     container: browser
     environ: { HOME: /tmp }
-    run: [firefox]
+    run: [firefox, --no-remote]

--- a/examples/firefox/vagga_webgl_intel.yaml
+++ b/examples/firefox/vagga_webgl_intel.yaml
@@ -1,12 +1,11 @@
 containers:
   browser:
     setup:
-    - !Ubuntu trusty
+    - !Ubuntu xenial
     - !UbuntuUniverse
-    - !Install [chromium-browser]
-    - !Install [firefox, icedtea-plugin]
-    - !Install [xserver-xorg-video-intel, mesa-utils, libgl1-mesa-dri]
-    - !EnsureDir /root
+    - !Install [chromium-browser,
+                 firefox, icedtea-plugin,
+                 xserver-xorg-video-intel, mesa-utils, libgl1-mesa-dri]
     volumes:
       /tmp: !Tmpfs
         size: 100Mi
@@ -14,10 +13,9 @@ containers:
         subdirs:
           .X11-unix:
       /tmp/.X11-unix: !BindRW /volumes/X11
-      /root: !BindRW /work/home
 
 commands:
   firefox: !Command
     container: browser
     environ: { HOME: /tmp }
-    run: [firefox]
+    run: [firefox, --no-remote]

--- a/examples/firefox/vagga_webgl_nvidia.yaml
+++ b/examples/firefox/vagga_webgl_nvidia.yaml
@@ -1,7 +1,7 @@
 containers:
   browser:
     setup:
-    - !Ubuntu trusty
+    - !Ubuntu xenial
     - !UbuntuUniverse
     - !Install [binutils, pkg-config, mesa-utils]
     - !Sh sh /work/NVIDIA-Linux-x86_64-331.67.run -a -N --ui=none --no-kernel-module
@@ -19,4 +19,4 @@ commands:
   firefox: !Command
     container: browser
     environ: { HOME: /tmp }
-    run: [firefox]
+    run: [firefox, --no-remote]


### PR DESCRIPTION
The identation for `!Install` might look weird in `vagga_webgl_intel.yaml` but that's actually how it has to be aligned in order for the generated docs identation to look nice(not a whitespace issue).