### PR TITLE
Remove need to build musl and llvm to build vagga

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -234,16 +234,10 @@ If output is empty, you have to modify these files. Command should be similar to
 Building From Source
 ====================
 
-The only supported way to build from source is to build with vagga. It's as
-easy as installing vagga and running ``vagga make`` inside the the clone of a
-vagga repository.
+The recommended way to is to build with vagga. It's as easy as installing vagga
+and running ``vagga make`` inside the the clone of a vagga repository.
 
-.. note:: First build of vagga is **very slow** because it needs to build
-   rust with musl standard library. When I say slow, I mean it takes about
-   1 (on fast i7) to 4 hours and more on a laptop. Subsequent builds are much
-   faster (less than minute on my laptop).
-
-   Alternatively you can run ``vagga cached-make`` instead of ``vagga make``.
+.. note:: Alternatively you can run ``vagga cached-make`` instead of ``vagga make``.
    This downloads pre-built image that we use to run in Travis CI. This may be
    changed in future.
 
@@ -260,7 +254,16 @@ or just (in case you don't have ``make`` in host system)::
 
 Both support ``PREFIX`` and ``DESTDIR`` environment variables.
 
-.. note:: We stopped supporting out-of-container build because rust with musl
-   is just too hard to build. In case you are brave enough, just look at
-   ``vagga.yaml`` in the repository. It's pretty easy to follow and there is
-   everything needed to build rust-musl with dependencies.
+You can also build vagga out-of-container by using rustup.rs. Make sure you
+have the musl target installed::
+
+    $ rustup target add x86_64-unknown-linux-musl
+
+Also make sure you have musl-gcc in your path::
+
+    $ which musl-gcc
+    /usr/bin/musl-gcc
+
+Then just build using cargo and the appropriate target::
+
+    $ cargo build --target x86_64-unknown-linux-musl

--- a/vagga.yaml
+++ b/vagga.yaml
@@ -16,33 +16,16 @@ containers:
     - !UbuntuUniverse
     - !Install [build-essential, ca-certificates]
     - !Install [file]  # dependency of checkinstall (bug #46)
-    - !BuildDeps [cmake, libc++-dev, curl, autoconf, automake, libtool]
-    # Build script derived from
-    # https://github.com/rust-lang/rust-buildbot/blob/master/slaves/linux/build-musl.sh
-    - !TarInstall
-      url: http://www.musl-libc.org/releases/musl-1.1.14.tar.gz
-      script: |
-        ./configure --prefix=/musl --disable-shared
-        make -j2
-        make install
 
-    - !Tar
-      url: http://llvm.org/releases/3.8.0/llvm-3.8.0.src.tar.xz
-      path: /tmp/llvm
     - !TarInstall
-      url: http://llvm.org/releases/3.8.0/libunwind-3.8.0.src.tar.xz
-      script: |
-        cmake . -DLLVM_PATH=/tmp/llvm/llvm-3.8.0.src -DLIBUNWIND_ENABLE_SHARED=0
-        make -j2
-        cp lib/libunwind.a /musl/lib
-    - !TarInstall
-      url: "http://static.rust-lang.org/dist/rust-1.9.0-x86_64-unknown-linux-gnu.tar.gz"
+      url: "https://static.rust-lang.org/dist/rust-1.9.0-x86_64-unknown-linux-gnu.tar.gz"
       script: "./install.sh --prefix=/usr --components=rustc,rust-std-x86_64-unknown-linux-gnu,cargo"
     - !TarInstall
-      url: "http://static.rust-lang.org/dist/rust-std-1.9.0-x86_64-unknown-linux-musl.tar.gz"
+      url: "https://static.rust-lang.org/dist/rust-std-1.9.0-x86_64-unknown-linux-musl.tar.gz"
       script: "./install.sh --prefix=/musl \
                --components=rust-std-x86_64-unknown-linux-musl"
     - !Sh 'ln -s /musl/lib/rustlib/x86_64-unknown-linux-musl /usr/lib/rustlib/x86_64-unknown-linux-musl'
+    - !Install [musl-tools]
 
     # For packaging
     - !Install [make, checkinstall, git, uidmap, wget, gcc, libc6-dev, ca-certificates]


### PR DESCRIPTION
This removes the need to build musl and llvm, as
no custom rust build is needed anymore. Musl GCC
is available from package repositories.

Also splits the build of the base container from
the build of the rust container, giving a good
breakpoint while working on changes.

Last part made it much easier for me to develop on
a flaky connection on a train ;).

Also fixes the problem that static.rust-lang.org is not
available though HTTP anymore.

This is definitely a bit rough, I will thoroughly test it later.

Also, on a sidenote, I ignored your readme and vagga now
builds just fine with rustup and the appropriate target.