### PR TITLE
Use SHA2 crate instead of Shaman

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
  "regex 0.1.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "scan_dir 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "shaman 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.5 (git+git://github.com/alexcrichton/tar-rs?rev=c402adf)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -301,11 +301,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "shaman"
-version = "0.1.0"
+name = "sha2"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Paul Colomiets"]
 [dependencies]
 libc = "0.2.10"
 nix = "0.5.0"
-shaman = "0.1.0"
+sha2 = "0.1.2"
 rand = "0.3.14"
 argparse = "0.2.1"
 rustc-serialize = "0.3.19"

--- a/src/builder/commands/ubuntu.rs
+++ b/src/builder/commands/ubuntu.rs
@@ -8,8 +8,7 @@ use std::collections::btree_map::Entry::{Vacant, Occupied};
 use quire::validate as V;
 use unshare::Stdio;
 use scan_dir::ScanDir;
-use shaman::sha2::Sha256;
-use shaman::digest::Digest as ShamanDigest;
+use sha2::{Sha256, Digest as Sha2Digest};
 
 use super::super::context::{Context};
 use super::super::download::download_file;

--- a/src/builder/download.rs
+++ b/src/builder/download.rs
@@ -4,8 +4,7 @@ use std::fs::{File, Permissions};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
-use shaman::digest::Digest;
-use shaman::sha2::Sha256;
+use sha2::{Digest, Sha256};
 use unshare::{Command, Stdio};
 
 use super::capsule;

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -6,18 +6,18 @@ use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{PermissionsExt, MetadataExt};
 
 use libc::{uid_t, gid_t};
-use shaman::sha2;
-use shaman::digest::Digest as DigestTrait;
+use sha2::Sha256;
+use sha2::Digest as DigestTrait;
 
-pub struct Digest(sha2::Sha256);
+pub struct Digest(Sha256);
 
 
 impl Digest {
     pub fn new() -> Digest {
-        Digest(sha2::Sha256::new())
+        Digest(Sha256::new())
     }
     // TODO(tailhook) get rid of the method
-    pub fn unwrap(self) -> sha2::Sha256 {
+    pub fn unwrap(self) -> Sha256 {
         return self.0
     }
     pub fn item<V: AsRef<[u8]>>(&mut self, value: V) {

--- a/src/file_util.rs
+++ b/src/file_util.rs
@@ -11,9 +11,6 @@ use nix;
 use libc::{uid_t, gid_t, c_int, utime, utimbuf};
 use nix::fcntl::{flock, FlockArg};
 
-use digest::Digest;
-
-
 extern "C" {
     fn lchown(path: *const i8, owner: uid_t, group: gid_t) -> c_int;
 }
@@ -192,7 +189,8 @@ impl Drop for Lock {
 
 pub fn check_stream_hashsum(mut reader: &mut Read, sha256: &String) -> Result<(), String>
 {
-    use shaman::digest::Digest as ShamanDigest;
+    use digest::Digest;
+    use sha2::Digest as Sha2Digest;
 
     let mut hash = Digest::new();
     try_msg!(hash.stream(&mut reader),

--- a/src/launcher/network.rs
+++ b/src/launcher/network.rs
@@ -19,8 +19,7 @@ use libmount::BindMount;
 use container::uidmap::get_max_uidmap;
 use super::super::config::Config;
 use super::super::container::nsutil::{set_namespace};
-use shaman::sha2::Sha256;
-use shaman::digest::Digest;
+use sha2::{Sha256, Digest};
 use file_util::{create_dir_mode};
 use process_util::{set_uidmap, env_command};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 
 use std::env;
 
-extern crate shaman;
+extern crate sha2;
 extern crate libc;
 extern crate nix;
 extern crate rand;

--- a/src/version/version.rs
+++ b/src/version/version.rs
@@ -1,5 +1,4 @@
-use shaman::sha2::Sha256;
-use shaman::digest::Digest as ShamanDigest;
+use sha2::{Sha256, Digest as Sha2Digest};
 
 use config::{Config, Container};
 use super::error::Error;


### PR DESCRIPTION
This patch removes the usage of the Shaman crate, using instead at his place.

Closes #254 