### PR TITLE
Remove time crate in favor of std::time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,15 +5,15 @@ dependencies = [
  "anymap 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "argparse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bzip2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "libmount 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mopa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quire 0.1.8 (git+git://github.com/tailhook/rust-quire?rev=72ec8fc)",
@@ -24,9 +24,8 @@ dependencies = [
  "sha2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.5 (git+git://github.com/alexcrichton/tar-rs?rev=c402adf)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "unshare 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xz2 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -65,7 +64,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bzip2-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -73,8 +72,8 @@ name = "bzip2-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -84,7 +83,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "env_logger"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -96,7 +95,7 @@ name = "filetime"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -104,13 +103,13 @@ name = "flate2"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gcc"
-version = "0.3.28"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -136,7 +135,7 @@ name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -147,7 +146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -155,7 +154,7 @@ name = "libmount"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -171,8 +170,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -185,7 +184,7 @@ name = "memchr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -193,8 +192,8 @@ name = "miniz-sys"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -209,18 +208,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "net2"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -239,7 +238,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -249,7 +248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -280,7 +279,7 @@ name = "rand"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -339,7 +338,7 @@ name = "signal"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -349,7 +348,7 @@ version = "0.4.5"
 source = "git+git://github.com/alexcrichton/tar-rs?rev=c402adf#c402adf543362c1e661a654e56fe4e1728352d9e"
 dependencies = [
  "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -358,7 +357,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -375,8 +374,8 @@ version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -397,13 +396,13 @@ name = "unshare"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "url"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -422,7 +421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -435,7 +434,7 @@ name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ rand = "0.3.14"
 argparse = "0.2.1"
 rustc-serialize = "0.3.19"
 log = "0.3.6"
-time = "0.1.35"
 env_logger = "0.3.3"
 url = "1.0.0"
 unshare = { version="0.1.11", optional=true }

--- a/src/builder/timer.rs
+++ b/src/builder/timer.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::path::Path;
 use std::fs::File;
 use std::fmt::{Arguments};
-use std::time::{Instant, Duration};
+use std::time::{Instant, Duration, SystemTime, UNIX_EPOCH};
 
 const NANO_FACTOR: f64 = 0.000000001;
 
@@ -20,13 +20,16 @@ pub struct TimeLog {
 
 impl TimeLog {
     pub fn start(path: &Path) -> Result<TimeLog, Error> {
-        let now = Instant::now();
+        let now = SystemTime::now();
+        let now_instant = Instant::now();
         let mut res = TimeLog {
             file: try!(File::create(path)),
-            start: now,
-            prev: now,
+            start: now_instant,
+            prev: now_instant,
         };
-        try!(res.mark(format_args!("Start {:?}", now)));
+        let duration = now.duration_since(UNIX_EPOCH)
+                          .expect("FATAL: now was created after the epoch");
+        try!(res.mark(format_args!("Start {:?}", duration_as_f64(duration))));
         Ok(res)
     }
     pub fn mark(&mut self, args: Arguments) -> Result<(), Error> {

--- a/src/builder/timer.rs
+++ b/src/builder/timer.rs
@@ -3,42 +3,39 @@ use std::io::Write;
 use std::path::Path;
 use std::fs::File;
 use std::fmt::{Arguments};
-
-use time::{self, Timespec};
+use std::time::{Instant, Duration};
 
 const NANO_FACTOR: f64 = 0.000000001;
 
 
-fn time_as_f64(tm: Timespec) -> f64 {
-    (tm.sec as f64) + (NANO_FACTOR * tm.nsec as f64)
+fn duration_as_f64(d: Duration) -> f64 {
+    (d.as_secs() as f64) + (NANO_FACTOR * d.subsec_nanos() as f64)
 }
 
 pub struct TimeLog {
     file: File,
-    start: Timespec,
-    prev: Timespec,
+    start: Instant,
+    prev: Instant,
 }
-
 
 impl TimeLog {
     pub fn start(path: &Path) -> Result<TimeLog, Error> {
-        let tm = time::get_time();
+        let now = Instant::now();
         let mut res = TimeLog {
             file: try!(File::create(path)),
-            start: tm,
-            prev: tm,
+            start: now,
+            prev: now,
         };
-        try!(res.mark(format_args!("Start {}", time_as_f64(tm))));
+        try!(res.mark(format_args!("Start {:?}", now)));
         Ok(res)
     }
     pub fn mark(&mut self, args: Arguments) -> Result<(), Error> {
-        let tm = time::get_time();
-        let tm_time = time_as_f64(tm);
-        let tm_start = tm_time - time_as_f64(self.start);
-        let tm_prev = tm_time - time_as_f64(self.prev);
-        write!(&mut self.file, "{:7.3} {:7.3}   ", tm_start, tm_prev)
+        let now = Instant::now();
+        let d_start = duration_as_f64(now.duration_since(self.start));
+        let d_prev = duration_as_f64(now.duration_since(self.prev));
+        write!(&mut self.file, "{:7.3} {:7.3}   ", d_start, d_prev)
         .and_then(|()| self.file.write_fmt(args))
         .and_then(|()| writeln!(&mut self.file, ""))
-        .map(|()| self.prev = tm)
+        .map(|()| self.prev = now)
     }
 }

--- a/src/launcher/supervisor.rs
+++ b/src/launcher/supervisor.rs
@@ -371,7 +371,7 @@ pub fn run(sup: &SuperviseInfo, args: Args, data: Data,
     // Stopping loop
     if children.len() > 0 {
         let timeo = sup.kill_unresponsive_after;
-        let mut deadline = Instant::now() + Duration::new(timeo.into(), 0);
+        let mut deadline = Instant::now() + Duration::from_secs(timeo as u64);
         loop {
             match trap.wait(deadline) {
                 Some(SIGINT) => {}
@@ -404,7 +404,7 @@ pub fn run(sup: &SuperviseInfo, args: Args, data: Data,
                         child.signal(SIGKILL).ok();
                     }
                     // Basically this deadline should never happen
-                    deadline = Instant::now() + Duration::new(3600, 0);
+                    deadline = Instant::now() + Duration::from_secs(3600);
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ extern crate rustc_serialize;
 extern crate env_logger;
 extern crate argparse;
 extern crate quire;
-extern crate time;
 extern crate signal;
 extern crate regex;
 extern crate scan_dir;


### PR DESCRIPTION
This ports all uses of the time crate over
to equivalents in std::time.

Note that this currently relies on a fork of the signal crate.