### PR TITLE
Hashing of included pip requirements

### DIFF
--- a/src/builder/commands/pip.rs
+++ b/src/builder/commands/pip.rs
@@ -335,7 +335,8 @@ fn version_req(hash: &mut Digest, fname: &Path, used: &mut HashSet<String>) ->
 
     let name = format!("{:?}", path);
     if used.contains(&name[..]) {
-        return Ok(())
+        return Err(VersionError::String(
+            format!("Cyclic requirement: {}", name)))
     }
 
     used.insert(name);
@@ -355,6 +356,7 @@ fn version_req(hash: &mut Digest, fname: &Path, used: &mut HashSet<String>) ->
             try!(version_req(hash,
                              &fname.parent().unwrap().join(req),
                              used));
+            continue;
         }
         // Should we also ignore the order?
         hash.item(chunk);

--- a/src/builder/commands/pip.rs
+++ b/src/builder/commands/pip.rs
@@ -1,4 +1,5 @@
 use std::fs::File;
+use std::collections::HashMap;
 use std::io::{BufReader, BufRead};
 use std::path::{Path, PathBuf};
 
@@ -314,14 +315,18 @@ impl BuildStep for Py3Install {
 }
 
 fn parse_req_filename(line: &str) -> Option<&str> {
-    if line.starts_with("-r") {
-        return Some(line[2..].trim())
-    } else if line.starts_with("--requirement ") ||
-              line.starts_with("--requirement=") {
-        return Some(line[14..].trim())
-    } else {
-        return None
+    let res =
+        vec!["-r", "--requirement ", "--requirement=",
+             "-c", "--constraint ", "--constraint="]
+            .into_iter()
+            .map(|x| (x, x.len()))
+            .collect::<HashMap<_, _>>();
+    for (prefix, pos) in res {
+        if line.starts_with(prefix) {
+            return Some(line[pos..].trim());
+        }
     }
+    return None;
 }
 
 fn version_req(hash: &mut Digest, fname: &Path) -> Result<(), VersionError> {

--- a/src/builder/commands/pip.rs
+++ b/src/builder/commands/pip.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::io::{BufReader, BufRead};
 use std::path::{Path, PathBuf};
 
@@ -315,15 +315,11 @@ impl BuildStep for Py3Install {
 }
 
 fn parse_req_filename(line: &str) -> Option<&str> {
-    let res =
-        vec!["-r", "--requirement ", "--requirement=",
-             "-c", "--constraint ", "--constraint="]
-            .into_iter()
-            .map(|x| (x, x.len()))
-            .collect::<HashMap<_, _>>();
-    for (prefix, pos) in res {
+    let res = vec!["-r", "--requirement ", "--requirement=",
+                   "-c", "--constraint ", "--constraint="];
+    for prefix in res.iter() {
         if line.starts_with(prefix) {
-            return Some(line[pos..].trim());
+            return Some(line[prefix.len()..].trim());
         }
     }
     return None;

--- a/tests/pip.bats
+++ b/tests/pip.bats
@@ -134,3 +134,21 @@ setup() {
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = $'pty_copy\r' ]]
 }
+
+@test "py3: recursive requirements files" {
+    echo 'urp' > /work/tests/pip/temp1.txt
+    echo 'cherrypy' > /work/tests/pip/temp2.txt
+    run sh -c 'vagga _version_hash py3req-recursive-reqs -s'
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    result="${lines[@]}"
+    echo 'aiohttp' >> /work/tests/pip/temp2.txt
+    run sh -c 'vagga _version_hash py3req-recursive-reqs -s'
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ ${lines[@]} != "$result" ]]
+    run vagga _run py3req-recursive-reqs python3 -m urp -Q key=val http://example.com
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
+}

--- a/tests/pip.bats
+++ b/tests/pip.bats
@@ -136,13 +136,11 @@ setup() {
 }
 
 @test "py3: recursive requirements files" {
-    echo 'urp' > /work/tests/pip/temp1.txt
-    echo 'cherrypy' > /work/tests/pip/temp2.txt
     run sh -c 'vagga _version_hash py3req-recursive-reqs -s'
     printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     result="${lines[@]}"
-    echo 'aiohttp' >> /work/tests/pip/temp2.txt
+    echo 'injections' >> /work/tests/pip/include-short.txt
     run sh -c 'vagga _version_hash py3req-recursive-reqs -s'
     printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]

--- a/tests/pip/include-nested.txt
+++ b/tests/pip/include-nested.txt
@@ -1,0 +1,1 @@
+--requirement include-short.txt

--- a/tests/pip/include-short.txt
+++ b/tests/pip/include-short.txt
@@ -1,0 +1,1 @@
+-r requirements.txt

--- a/tests/pip/reqs-included.txt
+++ b/tests/pip/reqs-included.txt
@@ -1,0 +1,3 @@
+-r temp1.txt
+--requirement=temp2.txt
+setuptools

--- a/tests/pip/reqs-included.txt
+++ b/tests/pip/reqs-included.txt
@@ -1,3 +1,0 @@
--r temp1.txt
---requirement=temp2.txt
-setuptools

--- a/tests/pip/vagga.yaml
+++ b/tests/pip/vagga.yaml
@@ -71,7 +71,7 @@ containers:
   py3req-recursive-reqs:
     setup:
     - !Alpine v3.2
-    - !Py3Requirements reqs-included.txt
+    - !Py3Requirements include-nested.txt
 
   py3req-inherit:
     setup:

--- a/tests/pip/vagga.yaml
+++ b/tests/pip/vagga.yaml
@@ -68,6 +68,11 @@ containers:
     - !Alpine v3.2
     - !Py3Requirements req-https.txt
 
+  py3req-recursive-reqs:
+    setup:
+    - !Alpine v3.2
+    - !Py3Requirements reqs-included.txt
+
   py3req-inherit:
     setup:
     - !Container py3req-https-alpine


### PR DESCRIPTION
What does it mean?
```
src/builder/commands/pip.rs:331:25: 332:74 warning: unused result which must be used, #[warn(unused_must_use)] on by default
src/builder/commands/pip.rs:331                         version_req(hash,
src/builder/commands/pip.rs:332                             fname.parent().unwrap().join(req).as_path());

```