### PR TITLE
Fixed documentation building

### DIFF
--- a/vagga.yaml
+++ b/vagga.yaml
@@ -5,6 +5,9 @@ containers:
     - !Alpine v3.4
     - !Install [alpine-base, py-sphinx, make]
     - !Py2Requirements docs/requirements.txt
+    # Seems like Alpine v3.4 has broken Sphinx package
+    # so install imagesize dependency manually
+    - !Py2Install [imagesize==0.7.1]
 
   rust-musl:
     environ: &rustenv


### PR DESCRIPTION
Don't understand how you could build documentation on ff8353f14d61af8ab604c68d5386bea190889ce7 since this commit was after upgrading Alpine to v3.4

```
% vagga doc
sphinx-build -b html -d _build/doctrees   . _build/html
Traceback (most recent call last):
  File "/usr/bin/sphinx-build", line 5, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2927, in <module>
    @_call_aside
  File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2913, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2940, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 635, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 943, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 829, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'imagesize' distribution was not found and is required by Sphinx
Makefile:53: recipe for target 'html' failed
make: *** [html] Error 1
```