### PR TITLE
Documentation for include-regex option

### DIFF
--- a/docs/build_steps.rst
+++ b/docs/build_steps.rst
@@ -576,6 +576,14 @@ Files and Directories
      Regular expression of paths to ignore. Default regexp ignores common
      revision control folders and editor backup files.
 
+   include-regex
+     (default ``None``)
+     Regular expression of paths to include. When path matches both ignore and
+     include expressions it will be ignored. Also note that if
+     ``include-regex`` matches only the folder, no contents will be included.
+     For example ``patches/.*\.sql$`` will copy all ``patches`` directories with
+     all ``.sql`` files inside them.
+
    owner-uid, owner-gid
      (preserved by default) Override uid and gid of files and directories when
      copying. It's expected that most useful case is ``owner-uid: 0`` and

--- a/src/builder/commands/copy.rs
+++ b/src/builder/commands/copy.rs
@@ -146,12 +146,11 @@ impl BuildStep for Copy {
                         // We know that it's decodable
                         let strpath = path.to_str().unwrap();
                         if filter.is_match(strpath) {
-                            let mut parents: Vec<_> = path
+                            let parents: Vec<_> = path
                                 .iter_self_and_parents()
                                 .take_while(|p| !processed_paths.contains(*p))
                                 .collect();
-                            parents.reverse();
-                            for parent in parents {
+                            for parent in parents.iter().rev() {
                                 let fdest = dest.join(parent);
                                 try!(shallow_copy(&src.join(parent), &fdest,
                                         self.owner_uid, self.owner_gid)


### PR DESCRIPTION
To disable `ignore-regex` we forced to use something like `^$` or `\A\z` which is not obvious. Should we disable `ignore-regex` initialized with empty string: `ignore-regex: ""`?