### PR TITLE
Improved Depends command: support directories and regular expression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "net2 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quire 0.1.8 (git+git://github.com/tailhook/rust-quire?rev=8a9bb1d)",
+ "quire 0.1.8 (git+git://github.com/tailhook/rust-quire?rev=72ec8fc)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -255,7 +255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "quire"
 version = "0.1.8"
-source = "git+git://github.com/tailhook/rust-quire?rev=8a9bb1d#8a9bb1d4d17dd01cc059af083ca4503bee34dec3"
+source = "git+git://github.com/tailhook/rust-quire?rev=72ec8fc#72ec8fc8558c15edf9e0ac009ba2dd682ad9c2e6"
 dependencies = [
  "argparse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ quick-error = "1.1.0"
 
 [dependencies.quire]
 git = "git://github.com/tailhook/rust-quire"
-rev = "8a9bb1d"
+rev = "72ec8fc"
 
 [[bin]]
 name = "vagga"

--- a/src/builder/commands/copy.rs
+++ b/src/builder/commands/copy.rs
@@ -1,10 +1,11 @@
 use std::io::ErrorKind;
 use std::fs::{symlink_metadata};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::os::unix::fs::{PermissionsExt, MetadataExt};
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use libc::{uid_t, gid_t};
+use quire::ast::{Ast, Tag};
 use quire::validate as V;
 use regex::{Regex, Error as RegexError};
 use scan_dir::ScanDir;
@@ -15,6 +16,54 @@ use path_util::IterSelfAndParents;
 use build_step::{BuildStep, VersionError, StepError, Digest, Config, Guard};
 use quick_error::ResultExt;
 
+
+#[derive(RustcDecodable, Debug)]
+pub struct Depends {
+    pub path: PathBuf,
+    pub ignore_regex: String,
+    pub include_regex: Option<String>,
+}
+
+fn depends_parser(ast: Ast) -> BTreeMap<String, Ast> {
+    match ast {
+        Ast::Scalar(pos, _, style, value) => {
+            let mut map = BTreeMap::new();
+            map.insert("path".to_string(),
+                Ast::Scalar(pos.clone(), Tag::NonSpecific, style, value));
+            map
+        },
+        _ => unreachable!(),
+    }
+}
+
+impl Depends {
+    pub fn config() -> V::Structure<'static> {
+        V::Structure::new()
+            .member("path", V::Scalar::new())
+            .member("ignore_regex", V::Scalar::new().default(
+                r#"(^|/)\.(git|hg|svn|vagga)($|/)|~$|\.bak$|\.orig$|^#.*#$"#))
+            .member("include_regex", V::Scalar::new().optional())
+            .parser(depends_parser)
+    }
+}
+
+impl BuildStep for Depends {
+    fn hash(&self, _cfg: &Config, hash: &mut Digest)
+        -> Result<(), VersionError>
+    {
+        let filter = try!(Filter::new(&self.ignore_regex, &self.include_regex));
+        let path = Path::new("/work").join(&self.path);
+        hash_path(hash, &path, &filter, None, None)
+    }
+    fn build(&self, _guard: &mut Guard, _build: bool)
+        -> Result<(), StepError>
+    {
+        Ok(())
+    }
+    fn is_dependent_on(&self) -> Option<&str> {
+        None
+    }
+}
 
 #[derive(RustcDecodable, Debug)]
 pub struct Copy {
@@ -37,31 +86,6 @@ impl Copy {
         .member("owner_uid", V::Numeric::new().min(0).optional())
         .member("owner_gid", V::Numeric::new().min(0).optional())
     }
-
-    fn get_filter(&self) -> Result<Filter, RegexError> {
-        Ok(Filter {
-            ignore_re: Some(try!(Regex::new(&self.ignore_regex))),
-            include_re: match self.include_regex {
-                Some(ref include_regex) => {
-                    Some(try!(Regex::new(include_regex)))
-                },
-                None => None,
-            },
-        })
-    }
-}
-
-struct Filter {
-    ignore_re: Option<Regex>,
-    include_re: Option<Regex>,
-}
-
-impl Filter {
-    fn is_match(&self, s: &str) -> bool
-    {
-        self.ignore_re.as_ref().map_or(true, |r| !r.is_match(s))
-            && self.include_re.as_ref().map_or(true, |r| r.is_match(s))
-    }
 }
 
 impl BuildStep for Copy {
@@ -70,56 +94,16 @@ impl BuildStep for Copy {
     {
         let ref src = self.source;
         if src.starts_with("/work") {
-            match symlink_metadata(src) {
-                Ok(ref meta) if meta.file_type().is_dir() => {
-                    let filter = try!(self.get_filter());
-                    try!(ScanDir::all().walk(src, |iter| {
-                        let mut all_paths = BTreeSet::new();
-                        for (entry, _) in iter {
-                            let fpath = entry.path();
-                            // We know that directory is inside
-                            // the source
-                            let path = fpath.strip_prefix(src).unwrap();
-                            // We know that path is decodable
-                            let strpath = path.to_str().unwrap();
-                            if filter.is_match(strpath) {
-                                for parent in path.iter_self_and_parents() {
-                                    if all_paths.contains(parent) {
-                                        break;
-                                    }
-                                    all_paths.insert(PathBuf::from(parent));
-                                }
-                            }
-                        }
-                        for cur_path in all_paths {
-                            hash.field("filename", cur_path.to_str().unwrap());
-                            try!(hash.file(&src.join(&cur_path),
-                                     self.owner_uid, self.owner_gid)
-                                 .map_err(|e| VersionError::Io(e, PathBuf::from(cur_path))));
-                        }
-                        Ok(())
-                    }).map_err(VersionError::ScanDir).and_then(|x| x));
-                }
-                Ok(_) => {
-                    try!(hash.file(src, self.owner_uid, self.owner_gid)
-                        .map_err(|e| VersionError::Io(e, src.into())));
-                }
-                Err(ref e) if e.kind() == ErrorKind::NotFound => {
-                    return Err(VersionError::New);
-                }
-                Err(e) => {
-                    return Err(VersionError::Io(e, src.into()));
-                }
-
-            }
+            let filter = try!(Filter::new(&self.ignore_regex, &self.include_regex));
+            hash_path(hash, src, &filter, self.owner_uid, self.owner_gid)
         } else {
             // We don't version the files outside of the /work because
             // we believe they are result of the commands run above
             //
             // And we need already built container to version the files
             // inside the container which is ugly
+            Ok(())
         }
-        Ok(())
     }
     fn build(&self, _guard: &mut Guard, build: bool)
         -> Result<(), StepError>
@@ -135,7 +119,7 @@ impl BuildStep for Copy {
             if typ.is_dir() {
                 try!(create_dir_mode(dest, typ.permissions().mode())
                     .map_err(|e| StepError::Write(dest.clone(), e)));
-                let filter = try!(self.get_filter());
+                let filter = try!(Filter::new(&self.ignore_regex, &self.include_regex));
                 let mut processed_paths = HashSet::new();
                 try!(ScanDir::all().walk(src, |iter| {
                     for (entry, _) in iter {
@@ -172,5 +156,79 @@ impl BuildStep for Copy {
     }
     fn is_dependent_on(&self) -> Option<&str> {
         None
+    }
+}
+
+fn hash_path(hash: &mut Digest, path: &Path,
+    filter: &Filter, owner_uid: Option<uid_t>, owner_gid: Option<gid_t>)
+    -> Result<(), VersionError>
+{
+    match symlink_metadata(path) {
+        Ok(ref meta) if meta.file_type().is_dir() => {
+            try!(ScanDir::all().walk(path, |iter| {
+                let mut all_paths = BTreeSet::new();
+                for (entry, _) in iter {
+                    let fpath = entry.path();
+                    // We know that directory is inside
+                    // the source
+                    let rel_path = fpath.strip_prefix(path).unwrap();
+                    // We know that path is decodable
+                    let strpath = rel_path.to_str().unwrap();
+                    if filter.is_match(strpath) {
+                        for parent in rel_path.iter_self_and_parents() {
+                            if all_paths.contains(parent) {
+                                break;
+                            }
+                            all_paths.insert(PathBuf::from(parent));
+                        }
+                    }
+                }
+                for cur_path in all_paths {
+                    hash.field("filename", cur_path.to_str().unwrap());
+                    try!(hash.file(&path.join(&cur_path),
+                                   owner_uid, owner_gid)
+                         .map_err(|e| VersionError::Io(e, PathBuf::from(cur_path))));
+                }
+                Ok(())
+            }).map_err(VersionError::ScanDir).and_then(|x| x));
+        }
+        Ok(_) => {
+            try!(hash.file(path, owner_uid, owner_gid)
+                 .map_err(|e| VersionError::Io(e, path.into())));
+        }
+        Err(ref e) if e.kind() == ErrorKind::NotFound => {
+            return Err(VersionError::New);
+        }
+        Err(e) => {
+            return Err(VersionError::Io(e, path.into()));
+        }
+    }
+    Ok(())
+}
+
+struct Filter {
+    ignore_re: Option<Regex>,
+    include_re: Option<Regex>,
+}
+
+impl Filter {
+    fn new(ignore_regex: &String, include_regex: &Option<String>)
+        -> Result<Filter, RegexError>
+    {
+        Ok(Filter {
+            ignore_re: Some(try!(Regex::new(ignore_regex))),
+            include_re: match *include_regex {
+                Some(ref include_regex) => {
+                    Some(try!(Regex::new(include_regex)))
+                },
+                None => None,
+            },
+        })
+    }
+
+    fn is_match(&self, s: &str) -> bool
+    {
+        self.ignore_re.as_ref().map_or(true, |r| !r.is_match(s))
+            && self.include_re.as_ref().map_or(true, |r| r.is_match(s))
     }
 }

--- a/src/builder/commands/copy.rs
+++ b/src/builder/commands/copy.rs
@@ -95,15 +95,16 @@ impl BuildStep for Copy {
         let ref src = self.source;
         if src.starts_with("/work") {
             let filter = try!(Filter::new(&self.ignore_regex, &self.include_regex));
-            hash_path(hash, src, &filter, self.owner_uid, self.owner_gid)
+            try!(hash_path(hash, src, &filter, self.owner_uid, self.owner_gid));
         } else {
             // We don't version the files outside of the /work because
             // we believe they are result of the commands run above
             //
             // And we need already built container to version the files
             // inside the container which is ugly
-            Ok(())
         }
+        hash.field("path", self.path.to_str().unwrap());
+        Ok(())
     }
     fn build(&self, _guard: &mut Guard, build: bool)
         -> Result<(), StepError>

--- a/src/builder/commands/generic.rs
+++ b/src/builder/commands/generic.rs
@@ -53,16 +53,6 @@ impl RunAs {
 }
 
 #[derive(Debug)]
-pub struct Depends(PathBuf);
-tuple_struct_decode!(Depends);
-
-impl Depends {
-    pub fn config() -> V::Scalar {
-        V::Scalar::new()
-    }
-}
-
-#[derive(Debug)]
 pub struct Env(BTreeMap<String, String>);
 tuple_struct_decode!(Env);
 
@@ -231,25 +221,6 @@ impl BuildStep for Sh {
         None
     }
 }
-
-impl BuildStep for Depends {
-    fn hash(&self, _cfg: &Config, hash: &mut Digest)
-        -> Result<(), VersionError>
-    {
-        let path = Path::new("/work").join(&self.0);
-        hash.file(&path, None, None)
-        .map_err(|e| VersionError::Io(e, path))
-    }
-    fn build(&self, _guard: &mut Guard, _build: bool)
-        -> Result<(), StepError>
-    {
-        Ok(())
-    }
-    fn is_dependent_on(&self) -> Option<&str> {
-        None
-    }
-}
-
 
 impl BuildStep for Cmd {
     fn hash(&self, _cfg: &Config, hash: &mut Digest)

--- a/src/config/builders.rs
+++ b/src/config/builders.rs
@@ -101,7 +101,7 @@ pub fn builder_validator<'x>() -> V::Enum<'x> {
     .option("EmptyDir", cmd::dirs::EmptyDir::config())
     .option("CacheDirs", cmd::dirs::CacheDirs::config())
     .option("Env", cmd::generic::Env::config())
-    .option("Depends", cmd::generic::Depends::config())
+    .option("Depends", cmd::copy::Depends::config())
     .option("Git", cmd::vcs::Git::config())
     .option("GitInstall", cmd::vcs::GitInstall::config())
     .option("Tar", cmd::tarcmd::Tar::config())
@@ -173,7 +173,7 @@ fn decode_step<D: Decoder>(options: &[&str], index: usize, d: &mut D)
         "CacheDirs" => step(cmd::dirs::CacheDirs::decode(d)),
         "EmptyDir" => step(cmd::dirs::EmptyDir::decode(d)),
         "Remove" => step(cmd::dirs::Remove::decode(d)),
-        "Depends" => step(cmd::generic::Depends::decode(d)),
+        "Depends" => step(cmd::copy::Depends::decode(d)),
         "Container" => step(cmd::subcontainer::Container::decode(d)),
         "Build" => step(cmd::subcontainer::Build::decode(d)),
         "SubConfig" => step(cmd::subcontainer::SubConfig::decode(d)),

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -12,7 +12,7 @@ setup() {
     [[ $status = 0 ]]
     [[ ${lines[@]} = "world file sub" ]]
     link=$(readlink .vagga/dir-copy)
-    [[ $link = ".roots/dir-copy.713b32f3/root" ]]
+    [[ $link = ".roots/dir-copy.51e81fd4/root" ]]
 }
 
 @test "copy: file" {
@@ -24,7 +24,7 @@ setup() {
     [[ $status = 0 ]]
     [[ ${lines[@]} = "data" ]]
     link=$(readlink .vagga/file-copy)
-    [[ $link = ".roots/file-copy.29314bfa/root" ]]
+    [[ $link = ".roots/file-copy.18b1ea7b/root" ]]
 }
 
 @test "copy: clean _unused (non-existent)" {
@@ -41,12 +41,27 @@ setup() {
     run env RUST_LOG=info vagga _build copy-with-include
     printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/copy-with-include)
-    [[ $link = ".roots/copy-with-include.624cf815/root" ]]
+    [[ $link = ".roots/copy-with-include.b17d4086/root" ]]
     [[ -f ".vagga/copy-with-include/dir/hello" ]]
     [[ -d ".vagga/copy-with-include/dir/subdir" ]]
     [[ $(stat -c "%a" ".vagga/copy-with-include/dir/subdir") = "750" ]]
     [[ -f ".vagga/copy-with-include/dir/subdir/file" ]]
     [[ ! -f ".vagga/copy-with-include/dir/second" ]]
     [[ $(vagga _version_hash copy-with-include) = $(vagga _version_hash copy-with-include-subdir) ]]
-    [[ $(vagga _version_hash copy-with-include) = $(vagga _version_hash depends-with-include) ]]
+}
+
+@test "depends: include regex" {
+    find dir -type d -print0 | xargs -0 chmod 0755
+    find dir -type f -print0 | xargs -0 chmod 0644
+    chmod 0750 dir/subdir
+
+    run vagga _version_hash --short depends-with-include
+    printf "%s\n" "${lines[@]}"
+    [[ $output = "624cf815" ]]
+
+    chmod 0755 dir/subdir
+
+    run vagga _version_hash --short depends-with-include
+    printf "%s\n" "${lines[@]}"
+    [[ $output = "e0800a77" ]]
 }

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -48,4 +48,5 @@ setup() {
     [[ -f ".vagga/copy-with-include/dir/subdir/file" ]]
     [[ ! -f ".vagga/copy-with-include/dir/second" ]]
     [[ $(vagga _version_hash copy-with-include) = $(vagga _version_hash copy-with-include-subdir) ]]
+    [[ $(vagga _version_hash copy-with-include) = $(vagga _version_hash depends-with-include) ]]
 }

--- a/tests/copy/vagga.yaml
+++ b/tests/copy/vagga.yaml
@@ -29,6 +29,11 @@ containers:
       source: /work/dir
       path: /dir
       include-regex: "(^hello|subdir|(^|.*/)file)$"
+  depends-with-include:
+    setup:
+    - !Depends
+      path: dir
+      include-regex: "(^hello|(^|.*/)file)$"
 
 commands:
 

--- a/tests/inheritance.bats
+++ b/tests/inheritance.bats
@@ -58,7 +58,7 @@ setup() {
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Hello World!" ]]
     link=$(readlink .vagga/hellocopyfrommount)
-    [[ $link = ".roots/hellocopyfrommount.f4d6f6cc/root" ]]
+    [[ $link = ".roots/hellocopyfrommount.f04b8732/root" ]]
 }
 
 @test "inheritance: Build copy" {


### PR DESCRIPTION
Do not merge this PR!

As you can see two different containers `copy-with-include` and `depends-with-include` produce the same version hash. I think it would be necessary to include command name into hash but this will break hash evaluation again.

Also I can't choose name for `Depends`'s `path` option cause for `Copy` command `path` means destination path. `source` is a bad name too because it implies existance of destination path.