### PR TITLE
Fix php integration

### DIFF
--- a/src/builder/commands/alpine.rs
+++ b/src/builder/commands/alpine.rs
@@ -21,6 +21,9 @@ static ALPINE_VERSION_REGEX: &'static str = r"^v\d+.\d+$";
 static MIRRORS: &'static str = include_str!("../../../alpine/MIRRORS.txt");
 
 
+const VERSION_WITH_PHP5: f32 = 3.4;
+
+
 // Build Steps
 #[derive(Debug)]
 pub struct Alpine(String);
@@ -70,7 +73,7 @@ impl Distribution for Distro {
         let mut to_install = vec!();
         let mut unsupp = vec!();
         for i in features.iter() {
-            if let Some(lst) = build_deps(*i) {
+            if let Some(lst) = self.build_deps(*i) {
                 for i in lst.into_iter() {
                     if !ctx.packages.contains(i) {
                         if ctx.build_deps.insert(i.to_string()) {
@@ -82,7 +85,7 @@ impl Distribution for Distro {
                 unsupp.push(*i);
                 continue;
             }
-            if let Some(lst) = system_deps(*i) {
+            if let Some(lst) = self.system_deps(*i) {
                 for i in lst.into_iter() {
                     let istr = i.to_string();
                     ctx.build_deps.remove(&istr);
@@ -122,6 +125,106 @@ impl Distribution for Distro {
                 .map_err(|e| format!("Error dumping package list: {}", e))
             }));
         Ok(())
+    }
+}
+
+impl Distro {
+    // fn version_as_f32(&self) -> f32 {
+    //     let version: &str = self.version.as_ref();
+    //     version.trim_left_matches('v').parse().expect("Invalid version")
+    // }
+
+    fn php_build_deps(&self) -> Vec<&'static str> {
+        let parsed_version: f32 = self.version
+            .trim_left_matches('v').parse().expect("Invalid version");
+
+        if parsed_version < VERSION_WITH_PHP5 {
+            vec!("php")
+        } else if parsed_version == VERSION_WITH_PHP5 {
+            vec!("php5")
+        } else {
+            vec!("php7")
+        }
+    }
+
+    fn php_system_deps(&self) -> Vec<&'static str> {
+        let parsed_version: f32 = self.version
+            .trim_left_matches('v').parse().expect("Invalid version");
+
+        if parsed_version < VERSION_WITH_PHP5 {
+            vec!(
+                "php", "php-cli", "php-openssl", "php-phar",
+                "php-json", "php-pdo", "php-dom", "php-zip"
+            )
+        } else if parsed_version == VERSION_WITH_PHP5 {
+            vec!(
+                "php5", "php5-cli", "php5-openssl", "php5-phar",
+                "php5-json", "php5-pdo", "php5-dom", "php5-zip"
+            )
+        } else {
+            vec!(
+                "php7", "php7-cli", "php7-openssl", "php7-phar",
+                "php7-json", "php7-pdo", "php7-dom", "php7-zip"
+            )
+        }
+    }
+
+    fn build_deps(&self, pkg: packages::Package) -> Option<Vec<&'static str>> {
+        match pkg {
+            packages::BuildEssential => Some(vec!("build-base")),
+            packages::Https => Some(vec!("ca-certificates")),
+            // Python
+            packages::Python2 => Some(vec!()),
+            packages::Python2Dev => Some(vec!("python-dev")),
+            packages::Python3 => Some(vec!()),
+            packages::Python3Dev => Some(vec!("python3-dev")),
+            packages::PipPy2 => None,
+            packages::PipPy3 => None,
+            // Node.js
+            packages::NodeJs => Some(vec!()),
+            packages::NodeJsDev => Some(vec!("nodejs-dev")),
+            packages::Npm => Some(vec!()),
+            // PHP
+            packages::Php => Some(vec!()),
+            packages::PhpDev => Some(self.php_build_deps()),
+            packages::Composer => None,
+            // Ruby
+            packages::Ruby => Some(vec!()),
+            packages::RubyDev => Some(vec!("ruby-dev")),
+            packages::Bundler => None,
+            // VCS
+            packages::Git => Some(vec!("git")),
+            packages::Mercurial => Some(vec!("mercurial")),
+        }
+    }
+
+    fn system_deps(&self, pkg: packages::Package) -> Option<Vec<&'static str>> {
+        match pkg {
+            packages::BuildEssential => Some(vec!()),
+            packages::Https => Some(vec!()),
+            // Python
+            packages::Python2 => Some(vec!("python")),
+            packages::Python2Dev => Some(vec!()),
+            packages::Python3 => Some(vec!("python3")),
+            packages::Python3Dev => Some(vec!()),
+            packages::PipPy2 => None,
+            packages::PipPy3 => None,
+            // Node.js
+            packages::NodeJs => Some(vec!("nodejs")),
+            packages::NodeJsDev => Some(vec!()),
+            packages::Npm => Some(vec!("nodejs")),  // Need duplicate?
+            // PHP
+            packages::Php => Some(self.php_system_deps()),
+            packages::PhpDev => Some(vec!()),
+            packages::Composer => None,
+            // Ruby
+            packages::Ruby => Some(vec!("ruby", "ruby-io-console")),
+            packages::RubyDev => Some(vec!()),
+            packages::Bundler => None,
+            // VCS
+            packages::Git => Some(vec!()),
+            packages::Mercurial => Some(vec!()),
+        }
     }
 }
 
@@ -178,67 +281,6 @@ pub fn remove(_ctx: &mut Context, pkgs: &Vec<String>)
         "--root", "/vagga/root",
         "del",
         ], &pkgs[..])
-}
-
-fn build_deps(pkg: packages::Package) -> Option<Vec<&'static str>> {
-    match pkg {
-        packages::BuildEssential => Some(vec!("build-base")),
-        packages::Https => Some(vec!("ca-certificates")),
-        // Python
-        packages::Python2 => Some(vec!()),
-        packages::Python2Dev => Some(vec!("python-dev")),
-        packages::Python3 => Some(vec!()),
-        packages::Python3Dev => Some(vec!("python3-dev")),
-        packages::PipPy2 => None,
-        packages::PipPy3 => None,
-        // Node.js
-        packages::NodeJs => Some(vec!()),
-        packages::NodeJsDev => Some(vec!("nodejs-dev")),
-        packages::Npm => Some(vec!()),
-        // PHP
-        packages::Php => Some(vec!()),
-        packages::PhpDev => Some(vec!("php-dev")),
-        packages::Composer => None,
-        // Ruby
-        packages::Ruby => Some(vec!()),
-        packages::RubyDev => Some(vec!("ruby-dev")),
-        packages::Bundler => None,
-        // VCS
-        packages::Git => Some(vec!("git")),
-        packages::Mercurial => Some(vec!("mercurial")),
-    }
-}
-
-fn system_deps(pkg: packages::Package) -> Option<Vec<&'static str>> {
-    match pkg {
-        packages::BuildEssential => Some(vec!()),
-        packages::Https => Some(vec!()),
-        // Python
-        packages::Python2 => Some(vec!("python")),
-        packages::Python2Dev => Some(vec!()),
-        packages::Python3 => Some(vec!("python3")),
-        packages::Python3Dev => Some(vec!()),
-        packages::PipPy2 => None,
-        packages::PipPy3 => None,
-        // Node.js
-        packages::NodeJs => Some(vec!("nodejs")),
-        packages::NodeJsDev => Some(vec!()),
-        packages::Npm => Some(vec!("nodejs")),  // Need duplicate?
-        // PHP
-        packages::Php => Some(vec!(
-            "php", "php-cli", "php-openssl", "php-phar",
-            "php-json", "php-pdo", "php-dom", "php-zip"
-        )),
-        packages::PhpDev => Some(vec!()),
-        packages::Composer => None,
-        // Ruby
-        packages::Ruby => Some(vec!("ruby", "ruby-io-console")),
-        packages::RubyDev => Some(vec!()),
-        packages::Bundler => None,
-        // VCS
-        packages::Git => Some(vec!()),
-        packages::Mercurial => Some(vec!()),
-    }
 }
 
 pub fn configure(distro: &mut Box<Distribution>, ctx: &mut Context,

--- a/src/builder/commands/alpine.rs
+++ b/src/builder/commands/alpine.rs
@@ -14,6 +14,7 @@ use super::super::packages;
 use process_util::capture_stdout;
 use builder::distrib::{Distribution, Named, DistroBox};
 use build_step::{BuildStep, VersionError, StepError, Digest, Config, Guard};
+use config::version::Version;
 
 
 pub static LATEST_VERSION: &'static str = "v3.4";
@@ -21,7 +22,7 @@ static ALPINE_VERSION_REGEX: &'static str = r"^v\d+.\d+$";
 static MIRRORS: &'static str = include_str!("../../../alpine/MIRRORS.txt");
 
 
-const VERSION_WITH_PHP5: f32 = 3.4;
+const VERSION_WITH_PHP5: &'static str = "v3.4";
 
 
 // Build Steps
@@ -130,12 +131,12 @@ impl Distribution for Distro {
 
 impl Distro {
     fn php_build_deps(&self) -> Vec<&'static str> {
-        let parsed_version: f32 = self.version
-            .trim_left_matches('v').parse().expect("Invalid version");
+        let version_with_php5 = Version(VERSION_WITH_PHP5);
+        let current_version = Version(self.version.as_ref());
 
-        if parsed_version < VERSION_WITH_PHP5 {
+        if current_version < version_with_php5 {
             vec!("php")
-        } else if parsed_version == VERSION_WITH_PHP5 {
+        } else if current_version == version_with_php5 {
             vec!("php5")
         } else {
             vec!("php7")
@@ -143,15 +144,15 @@ impl Distro {
     }
 
     fn php_system_deps(&self) -> Vec<&'static str> {
-        let parsed_version: f32 = self.version
-            .trim_left_matches('v').parse().expect("Invalid version");
+        let version_with_php5 = Version(VERSION_WITH_PHP5);
+        let current_version = Version(self.version.as_ref());
 
-        if parsed_version < VERSION_WITH_PHP5 {
+        if current_version < version_with_php5 {
             vec!(
                 "php", "php-cli", "php-openssl", "php-phar",
                 "php-json", "php-pdo", "php-dom", "php-zip"
             )
-        } else if parsed_version == VERSION_WITH_PHP5 {
+        } else if current_version == version_with_php5 {
             vec!(
                 "php5", "php5-cli", "php5-openssl", "php5-phar",
                 "php5-json", "php5-pdo", "php5-dom", "php5-zip"

--- a/src/builder/commands/alpine.rs
+++ b/src/builder/commands/alpine.rs
@@ -129,11 +129,6 @@ impl Distribution for Distro {
 }
 
 impl Distro {
-    // fn version_as_f32(&self) -> f32 {
-    //     let version: &str = self.version.as_ref();
-    //     version.trim_left_matches('v').parse().expect("Invalid version")
-    // }
-
     fn php_build_deps(&self) -> Vec<&'static str> {
         let parsed_version: f32 = self.version
             .trim_left_matches('v').parse().expect("Invalid version");

--- a/src/builder/commands/composer.rs
+++ b/src/builder/commands/composer.rs
@@ -302,7 +302,7 @@ fn setup_include_path(ctx: &mut Context) -> Result<(), String> {
     }
 
     // create vagga.ini file
-    try!(create_vagga_ini(&conf_d, &vagga_ini_content));
+    try!(create_vagga_ini(&conf_d.join("vagga.ini"), &vagga_ini_content));
 
     Ok(())
 }
@@ -314,24 +314,60 @@ fn create_vagga_ini(location: &Path, content: &str) -> Result<(), String> {
 }
 
 fn find_conf_dirs() -> Result<Vec<PathBuf>, scan_dir::Error> {
-    ScanDir::dirs().skip_symlinks(true).read("/vagga/root/etc", |iter| {
-        iter.filter(|&(_, ref name)| name.starts_with("php"))
-        .flat_map(|(ref entry, _)| {
-            ScanDir::dirs().walk(entry.path(), |iter| {
-                iter.filter(|&(ref entry, ref name)| {
-                    name == "conf.d" ||
-                    entry.path().join("conf.d").exists()
-                })
-                .map(|(ref entry, _)| {
-                    let path = entry.path();
-                    if path.ends_with("conf.d") { path }
-                    else { path.join("conf.d") }
-                })
-                .collect()
-            })
+    let mut dirs = Vec::new();
+
+    // find php main config directory (/etc/php or /etc/php5)
+    let etc_php: Vec<PathBuf> = try!(
+        ScanDir::dirs().skip_symlinks(true).read("/vagga/root/etc", |iter| {
+            iter.filter(|&(_, ref name)| name.starts_with("php"))
+            .map(|(ref entry, _)| entry.path())
+            .collect()
         })
-        .collect()
-    })
+    );
+
+    // get subdirectories of main php config directory
+    let mut etc_php_dirs = Vec::new();
+    for path in etc_php.iter() {
+        try!(ScanDir::dirs().skip_symlinks(true).read(path, |iter| {
+            for (ref entry, _) in iter {
+                etc_php_dirs.push(entry.path())
+            }
+        }));
+    }
+
+    // In ubuntu xenial, /etc/php directory structure was changed, now it's like:
+    // /etc/php
+    // └── 7.0
+    //     ├── cli
+    //     ├── fpm
+    //     └── mods-available
+    // instead of:
+    // /etc/php5
+    // ├── cli
+    // ├── fpm
+    // └── mods-available
+    // because of the extra directory for the php version, we need to search one more
+    // level down the directory tree, otherwise the `conf.d` directory would not be
+    // found in ubuntu xenial
+    for path in etc_php_dirs.iter() {
+        try!(ScanDir::dirs().skip_symlinks(true).read(path, |iter| {
+            for (ref entry, _) in iter {
+                dirs.push(entry.path())
+            }
+        }));
+    }
+
+    dirs.append(&mut etc_php_dirs);
+
+    Ok(dirs.into_iter().filter_map(|path| {
+        if path.ends_with("conf.d") {
+            Some(path)
+        } else if path.join("conf.d").exists() {
+            Some(path.join("conf.d"))
+        } else {
+            None
+        }
+    }).collect())
 }
 
 fn ask_php_for_conf_d(ctx: &mut Context) -> Result<PathBuf, String> {

--- a/src/builder/commands/composer.rs
+++ b/src/builder/commands/composer.rs
@@ -300,6 +300,7 @@ fn setup_include_path(ctx: &mut Context) -> Result<(), String> {
         try!(file_util::create_dir(&conf_d, true)
         .map_err(|e| format!("Error creating directory {:?}: {}", conf_d, e)));
     }
+
     // create vagga.ini file
     try!(create_vagga_ini(&conf_d, &vagga_ini_content));
 
@@ -316,7 +317,7 @@ fn find_conf_dirs() -> Result<Vec<PathBuf>, scan_dir::Error> {
     ScanDir::dirs().skip_symlinks(true).read("/vagga/root/etc", |iter| {
         iter.filter(|&(_, ref name)| name.starts_with("php"))
         .flat_map(|(ref entry, _)| {
-            ScanDir::dirs().read(entry.path(), |iter| {
+            ScanDir::dirs().walk(entry.path(), |iter| {
                 iter.filter(|&(ref entry, ref name)| {
                     name == "conf.d" ||
                     entry.path().join("conf.d").exists()

--- a/src/builder/commands/ubuntu.rs
+++ b/src/builder/commands/ubuntu.rs
@@ -437,7 +437,7 @@ impl Distro {
             packages::Npm => Some(vec!()),
             // PHP
             packages::Php if self.has_php7() => {
-                Some(vec!("php-common", "php-cli"))
+                Some(vec!("php-common", "php-cli", "php-json", "php-zip"))
             }
             packages::Php => Some(vec!("php5-common", "php5-cli")),
             packages::PhpDev => Some(vec!()),
@@ -913,4 +913,3 @@ impl EMDParams {
         }
     }
 }
-

--- a/src/builder/commands/ubuntu.rs
+++ b/src/builder/commands/ubuntu.rs
@@ -437,6 +437,8 @@ impl Distro {
             packages::Npm => Some(vec!()),
             // PHP
             packages::Php if self.has_php7() => {
+                // In ubuntu xenial, php package does not bundles the json and zip modules required
+                // by Composer
                 Some(vec!("php-common", "php-cli", "php-json", "php-zip"))
             }
             packages::Php => Some(vec!("php5-common", "php5-cli")),

--- a/tests/composer.bats
+++ b/tests/composer.bats
@@ -15,7 +15,7 @@ teardown() {
     [[ $output = *"Composer version"* ]]
     [[ ! -f ".vagga/composer-lifecycle/usr/local/bin/composer" ]]
     link=$(readlink .vagga/composer-lifecycle)
-    [[ $link = ".roots/composer-lifecycle.8b3cf329/root" ]]
+    [[ $link = ".roots/composer-lifecycle.e9e6610b/root" ]]
 }
 
 @test "composer: keep composer after build" {
@@ -33,6 +33,15 @@ teardown() {
 }
 
 # php
+
+@test "composer: php ubuntu xenial" {
+    run vagga _run php-ubuntu-xenial laravel --version
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ ${lines[${#lines[@]}-1]} = "Laravel Installer version 1.3.0" ]]
+    link=$(readlink .vagga/php-ubuntu-xenial)
+    [[ $link = ".roots/php-ubuntu-xenial.87465c41/root" ]]
+}
 
 @test "composer: php ubuntu trusty" {
     run vagga _run php-ubuntu-trusty laravel --version
@@ -52,22 +61,31 @@ teardown() {
     [[ $link = ".roots/php-ubuntu-precise.57872fd3/root" ]]
 }
 
-@test "composer: php alpine 3.3" {
-    run vagga _run php-alpine-3-3 laravel --version
+@test "composer: php alpine 3.4" {
+    run vagga _run php-alpine-3_4 laravel --version
     printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer version 1.3.0" ]]
-    link=$(readlink .vagga/php-alpine-3-3)
-    [[ $link = ".roots/php-alpine-3-3.2a51fce5/root" ]]
+    link=$(readlink .vagga/php-alpine-3_4)
+    [[ $link = ".roots/php-alpine-3_4.730f7f8f/root" ]]
+}
+
+@test "composer: php alpine 3.3" {
+    run vagga _run php-alpine-3_3 laravel --version
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ ${lines[${#lines[@]}-1]} = "Laravel Installer version 1.3.0" ]]
+    link=$(readlink .vagga/php-alpine-3_3)
+    [[ $link = ".roots/php-alpine-3_3.2a51fce5/root" ]]
 }
 
 @test "composer: php alpine 3.2" {
-    run vagga _run php-alpine-3-2 laravel --version
+    run vagga _run php-alpine-3_2 laravel --version
     printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer version 1.3.0" ]]
-    link=$(readlink .vagga/php-alpine-3-2)
-    [[ $link = ".roots/php-alpine-3-2.5153e63b/root" ]]
+    link=$(readlink .vagga/php-alpine-3_2)
+    [[ $link = ".roots/php-alpine-3_2.5153e63b/root" ]]
 }
 
 @test "composer: php ComposerDependencies" {
@@ -76,7 +94,25 @@ teardown() {
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer version 1.3.0" ]]
     link=$(readlink .vagga/php-composer-deps)
-    [[ $link = ".roots/php-composer-deps.261391c4/root" ]]
+    [[ $link = ".roots/php-composer-deps.e581a959/root" ]]
+}
+
+@test "composer: php ComposerDependencies ubuntu xenial" {
+    run vagga _run php-composer-deps-ubuntu-xenial laravel --version
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ ${lines[${#lines[@]}-1]} = "Laravel Installer version 1.3.0" ]]
+    link=$(readlink .vagga/php-composer-deps-ubuntu-xenial)
+    [[ $link = ".roots/php-composer-deps-ubuntu-xenial.e3a858bd/root" ]]
+}
+
+@test "composer: php ComposerDependencies ubuntu trusty" {
+    run vagga _run php-composer-deps-ubuntu-trusty laravel --version
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ ${lines[${#lines[@]}-1]} = "Laravel Installer version 1.3.0" ]]
+    link=$(readlink .vagga/php-composer-deps-ubuntu-trusty)
+    [[ $link = ".roots/php-composer-deps-ubuntu-trusty.592bc51f/root" ]]
 }
 
 @test "composer: php ComposerDependencies dev" {
@@ -85,16 +121,25 @@ teardown() {
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Hello, Vagga!" ]]
     link=$(readlink .vagga/php-composer-dev-deps)
-    [[ $link = ".roots/php-composer-dev-deps.dad1c2e2/root" ]]
+    [[ $link = ".roots/php-composer-dev-deps.5f703887/root" ]]
 }
 
-@test "composer: php ComposerDependencies dev ubuntu" {
-    run vagga _run php-composer-dev-deps-ubuntu task greet
+@test "composer: php ComposerDependencies dev ubuntu xenial" {
+    run vagga _run php-composer-dev-deps-ubuntu-xenial task greet
     printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Hello, Vagga!" ]]
-    link=$(readlink .vagga/php-composer-dev-deps-ubuntu)
-    [[ $link = ".roots/php-composer-dev-deps-ubuntu.fe7ec5ad/root" ]]
+    link=$(readlink .vagga/php-composer-dev-deps-ubuntu-xenial)
+    [[ $link = ".roots/php-composer-dev-deps-ubuntu-xenial.d4b00831/root" ]]
+}
+
+@test "composer: php ComposerDependencies dev ubuntu trusty" {
+    run vagga _run php-composer-dev-deps-ubuntu-trusty task greet
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ ${lines[${#lines[@]}-1]} = "Hello, Vagga!" ]]
+    link=$(readlink .vagga/php-composer-dev-deps-ubuntu-trusty)
+    [[ $link = ".roots/php-composer-dev-deps-ubuntu-trusty.fe7ec5ad/root" ]]
 }
 
 @test "composer: php ComposerDependencies prefer dist" {
@@ -103,7 +148,7 @@ teardown() {
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Hello, Vagga!" ]]
     link=$(readlink .vagga/php-composer-deps-prefer-dist)
-    [[ $link = ".roots/php-composer-deps-prefer-dist.dad1c2e2/root" ]]
+    [[ $link = ".roots/php-composer-deps-prefer-dist.5f703887/root" ]]
 }
 
 @test "composer: php ComposerDependencies wrong prefer" {
@@ -126,12 +171,11 @@ teardown() {
 
 # hhvm
 
-@test "composer: hhvm ubuntu trusty" {
-    skip
-    run vagga _run hhvm-ubuntu-trusty laravel --version
+@test "composer: hhvm ubuntu xenial" {
+    run vagga _run hhvm-ubuntu-xenial laravel --version
     printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer version 1.3.0" ]]
-    link=$(readlink .vagga/hhvm-ubuntu-trusty)
-    [[ $link = ".roots/hhvm-ubuntu-trusty.5222979f/root" ]]
+    link=$(readlink .vagga/hhvm-ubuntu-xenial)
+    [[ $link = ".roots/hhvm-ubuntu-xenial.189813c0/root" ]]
 }

--- a/tests/composer/vagga.yaml
+++ b/tests/composer/vagga.yaml
@@ -2,26 +2,32 @@ containers:
   # test composer is available in PATH and removed after container is built
   composer-lifecycle:
     setup:
-    - !Alpine v3.3
+    - !Alpine v3.4
     - !ComposerInstall
     - !Sh composer --version
 
   keep-composer:
     setup:
-    - !Alpine v3.3
+    - !Alpine v3.4
     - !ComposerConfig
       keep_composer: true
     - !ComposerInstall
 
   change-vendor-dir:
     setup:
-    - !Alpine v3.3
+    - !Alpine v3.4
     - !EnsureDir /usr/local/dependencies/vendor
     - !ComposerConfig
       vendor_dir: /usr/local/dependencies/vendor
     - !ComposerInstall [nette/tester:1.7.0]
 
   # php
+
+  php-ubuntu-xenial:
+    setup:
+    - !Ubuntu xenial
+    - !ComposerInstall ["laravel/installer:1.3.0"]
+
   php-ubuntu-trusty:
     setup:
     - !Ubuntu trusty
@@ -33,47 +39,67 @@ containers:
     - !Install [php5-cgi]
     - !ComposerInstall ["nette/tester:1.7.0"]
 
-  php-alpine-3-3:
+  php-alpine-3_4:
+    setup:
+    - !Alpine v3.4
+    - !ComposerInstall ["laravel/installer:1.3.0"]
+
+  php-alpine-3_3:
     setup:
     - !Alpine v3.3
     - !ComposerInstall ["laravel/installer:1.3.0"]
 
-  php-alpine-3-2:
+  php-alpine-3_2:
     setup:
     - !Alpine v3.2
     - !ComposerInstall ["laravel/installer:1.3.0"]
 
   php-composer-deps:
     setup:
-    - !Alpine v3.3
+    - !Alpine v3.4
+    - !ComposerDependencies { dev: false }
+
+  php-composer-deps-ubuntu-xenial:
+    setup:
+    - !Ubuntu xenial
+    - !ComposerDependencies { dev: false }
+
+  php-composer-deps-ubuntu-trusty:
+    setup:
+    - !Ubuntu trusty
     - !ComposerDependencies { dev: false }
 
   php-composer-dev-deps:
     setup:
-    - !Alpine v3.3
+    - !Alpine v3.4
     - !ComposerDependencies
 
-  php-composer-dev-deps-ubuntu:
+  php-composer-dev-deps-ubuntu-xenial:
+    setup:
+    - !Ubuntu xenial
+    - !ComposerDependencies
+
+  php-composer-dev-deps-ubuntu-trusty:
     setup:
     - !Ubuntu trusty
     - !ComposerDependencies
 
   php-composer-deps-prefer-dist:
     setup:
-    - !Alpine v3.3
+    - !Alpine v3.4
     - !ComposerDependencies
       prefer: dist
 
   php-composer-deps-wrong-prefer:
     setup:
-    - !Alpine v3.3
+    - !Alpine v3.4
     - !ComposerDependencies
       prefer: wrong
 
   # hhvm
   hhvm-base:
     setup:
-    - !Ubuntu trusty
+    - !Ubuntu xenial
     - !UbuntuUniverse
     - !AptTrust keys: [5a16e7281be7a449]
     - !UbuntuRepo
@@ -86,9 +112,14 @@ containers:
       runtime_exe: /usr/bin/hhvm
     - !Sh echo 'include_path=.:/usr/local/lib/composer' >> /etc/hhvm/php.ini
 
-  hhvm-ubuntu-trusty:
+  hhvm-ubuntu-xenial:
     setup:
-    - !Container hhvm-base
+    - !Ubuntu xenial
+    - !UbuntuUniverse
+    - !Install [hhvm]
+    - !ComposerConfig
+      install_runtime: false
+    - !Sh echo 'include_path=.:/usr/local/lib/composer' >> /etc/hhvm/php.ini
     - !ComposerInstall ["laravel/installer:1.3.0"]
     environ:
       HHVM_REPO_CENTRAL_PATH: /run/hhvm.hhbc

--- a/tests/composer/vagga.yaml
+++ b/tests/composer/vagga.yaml
@@ -97,21 +97,6 @@ containers:
       prefer: wrong
 
   # hhvm
-  hhvm-base:
-    setup:
-    - !Ubuntu xenial
-    - !UbuntuUniverse
-    - !AptTrust keys: [5a16e7281be7a449]
-    - !UbuntuRepo
-      url: http://dl.hhvm.com/ubuntu
-      suite: trusty
-      components: [main]
-    - !Install [hhvm]
-    - !ComposerConfig
-      install_runtime: false
-      runtime_exe: /usr/bin/hhvm
-    - !Sh echo 'include_path=.:/usr/local/lib/composer' >> /etc/hhvm/php.ini
-
   hhvm-ubuntu-xenial:
     setup:
     - !Ubuntu xenial


### PR DESCRIPTION
Both Ubuntu xenial and Alpine 3.4 changed things for php.

Ubuntu added php7 and named its package just "php" with some modules not present in the main package compared to previous version (php-zip for instance).

Alpine changed the "php" package to "php5" in preparation for the upcoming "php7", which will probably be present in Alpine 3.5.

Ubuntu also added "hhvm" to the repository in xenail, so a test was added for that interpreter.