### PR TITLE
AlpineRepo and Repo commands

### DIFF
--- a/docs/build_steps.rst
+++ b/docs/build_steps.rst
@@ -229,7 +229,7 @@ Alpine Commands
        url: http://nl.alpinelinux.org/alpine/
        branch: edge
        repo: testing
-       alias: testing
+       tag: testing
      - !Install [app@testing]
 
    Options:
@@ -246,10 +246,17 @@ Alpine Commands
      Repository to fetch packages from. For example ``main``, ``community``,
      ``testing``. **Required**.
 
-   alias
-     Alias or "pin" for this repository. Alpine package manager will now
-     by default only use the untagged repositories. Adding an alias to
-     specific package will prefer the repository with that alias.
+   tag
+     Tag for this repository. Alpine package manager will now
+     by default only use the untagged repositories. Adding a tag to
+     specific package will prefer the repository with that tag.
+     To add a tag just put ``@tag`` after the package name. For example::
+
+       - !AlpineRepo
+         branch: edge
+         repo: testing
+         tag: testing
+       - !Install [graphicsmagick@testing]
 
 
 Distribution Commands

--- a/docs/build_steps.rst
+++ b/docs/build_steps.rst
@@ -166,16 +166,22 @@ Ubuntu Commands
    Options:
 
    url
-     Url to the repository. **Required**.
+     Url to the repository. Default is the mirror url from the current ubuntu
+     distribution.
 
    suite
      Suite of the repository. The common practice is that the suite is named just
-     like the codename of the ubuntu release. For example ``xenial``. **Required**.
+     like the codename of the ubuntu release. For example ``xenial``. Default is
+     the codename of the current distribution.
 
    components
      List of the components to fetch packages from. Common practice to have a
      ``main`` component. So usually this setting contains just single
      element ``components: [main]``. **Required**.
+
+   trusted
+     Marks repository as trusted. Usually useful for installing unsigned packages
+     from local repository. Default is ``false``.
 
 .. step:: UbuntuPPA
 
@@ -215,6 +221,36 @@ Alpine Commands
    setup:
    - !Alpine v3.4
 
+.. step:: AlpineRepo
+
+   Adds arbitrary alpine repository. For example to add testing repository::
+
+     - !AlpineRepo
+       url: http://nl.alpinelinux.org/alpine/
+       branch: edge
+       repo: testing
+       alias: testing
+     - !Install [app@testing]
+
+   Options:
+
+   url
+     Url to the repository. Default is the mirror url from the current alpine
+     distribution.
+
+   branch
+     Branch of the repository. For example ``v3.4``, ``edge``. Default is
+     the version of the current alpine distribution.
+
+   repo
+     Repository to fetch packages from. For example ``main``, ``community``,
+     ``testing``. **Required**.
+
+   alias
+     Alias or "pin" for this repository. Alpine package manager will now
+     by default only use the untagged repositories. Adding an alias to
+     specific package will prefer the repository with that alias.
+
 
 Distribution Commands
 =====================
@@ -223,6 +259,28 @@ These commands work for any linux distributions as long as distribution is
 detected by vagga. Latter basically means you used :step:`Alpine`,
 :step:`Ubuntu`, :step:`UbuntuRelease` in container config (or in parent
 config if you use :step:`SubConfig` or :step:`Container`)
+
+.. step:: Repo
+
+   Adds official repository to the supported linux distribution. For example::
+
+     setup:
+     - !Ubuntu xenial
+     - !Repo xenial/universe
+     - !Repo xenial-security/universe
+     - !Repo xenial-updates/universe
+
+     setup:
+     - !Ubuntu xenial
+     - !Repo universe # The same as "xenial/universe"
+
+     setup:
+     - !Alpine v3.4
+     - !Repo edge/testing
+
+     setup:
+     - !Alpine v3.4
+     - !Repo community # The same as "v3.4/community"
 
 .. step:: Install
 

--- a/src/builder/commands/alpine.rs
+++ b/src/builder/commands/alpine.rs
@@ -1,5 +1,6 @@
 use std::io::Write;
-use std::fs::File;
+use std::fs::{File, OpenOptions};
+use std::fmt::{Write as WriteFmt};
 use std::path::Path;
 
 use quire::validate as V;
@@ -30,9 +31,27 @@ const VERSION_WITH_PHP5: &'static str = "v3.4";
 pub struct Alpine(String);
 tuple_struct_decode!(Alpine);
 
+#[derive(Debug, RustcDecodable)]
+pub struct AlpineRepo {
+    url: Option<String>,
+    branch: Option<String>,
+    repo: String,
+    alias: Option<String>,
+}
+
 impl Alpine {
     pub fn config() -> V::Scalar {
         V::Scalar::new()
+    }
+}
+
+impl AlpineRepo {
+    pub fn config() -> V::Structure<'static> {
+        V::Structure::new()
+        .member("url", V::Scalar::new().optional())
+        .member("branch", V::Scalar::new().optional())
+        .member("repo", V::Scalar::new())
+        .member("alias", V::Scalar::new().optional())
     }
 }
 
@@ -40,7 +59,9 @@ impl Alpine {
 #[derive(Debug)]
 pub struct Distro {
     pub version: String,
+    pub mirror: String,
     pub base_setup: bool,
+    pub apk_update: bool,
 }
 
 impl Named for Distro {
@@ -52,7 +73,7 @@ impl Distribution for Distro {
     fn bootstrap(&mut self, ctx: &mut Context) -> Result<(), StepError> {
         if !self.base_setup {
             self.base_setup = true;
-            try!(setup_base(ctx, &self.version));
+            try!(setup_base(ctx, &self.version, &self.mirror));
         }
         Ok(())
     }
@@ -60,10 +81,14 @@ impl Distribution for Distro {
         -> Result<(), StepError>
     {
         try!(self.bootstrap(ctx));
-        try!(capsule::apk_run(&[
-            "--root", "/vagga/root",
-            "add",
-            ], &pkgs[..]));
+        let mut apk_args = vec!();
+        if self.apk_update {
+            self.apk_update = false;
+            apk_args.push("--update-cache");
+        }
+        apk_args.extend(&["--root", "/vagga/root"]);
+        apk_args.push("add");
+        try!(capsule::apk_run(&apk_args, &pkgs[..]));
         Ok(())
     }
     fn ensure_packages(&mut self, ctx: &mut Context,
@@ -130,6 +155,34 @@ impl Distribution for Distro {
 }
 
 impl Distro {
+    pub fn add_repo(&mut self, _: &mut Context, repo: &AlpineRepo)
+        -> Result<(), String>
+    {
+        self.apk_update = true;
+
+        let mut repo_line = String::new();
+        if let Some(ref alias) = repo.alias {
+            write!(&mut repo_line, "@{} ", alias).unwrap();
+        }
+        let url = repo.url.as_ref().unwrap_or(&self.mirror);
+        let normalized_url = if !url.ends_with("/") {
+            format!("{}/", url)
+        } else {
+            url.to_string()
+        };
+        write!(&mut repo_line, "{}", normalized_url).unwrap();
+        write!(&mut repo_line, "{}/{}",
+            &repo.branch.as_ref().unwrap_or(&self.version),
+            &repo.repo).unwrap();
+
+        try!(OpenOptions::new().append(true)
+            .open("/vagga/root/etc/apk/repositories")
+            .and_then(|mut f| write!(&mut f, "{}\n", &repo_line))
+            .map_err(|e| format!("Can't write repositories file: {}", e)));
+
+        Ok(())
+    }
+
     fn php_build_deps(&self) -> Vec<&'static str> {
         let version_with_php5 = Version(VERSION_WITH_PHP5);
         let current_version = Version(self.version.as_ref());
@@ -245,15 +298,13 @@ fn check_version(version: &String) -> Result<(), String> {
     }
 }
 
-fn setup_base(ctx: &mut Context, version: &String)
+fn setup_base(ctx: &mut Context, version: &String, mirror: &String)
     -> Result<(), String>
 {
     try!(capsule::ensure_features(ctx, &[capsule::AlpineInstaller]));
     try!(check_version(version));
     try_msg!(create_dir("/vagga/root/etc/apk", true),
         "Error creating apk dir: {err}");
-    let mirror = ctx.settings.alpine_mirror.clone()
-        .unwrap_or(choose_mirror());
     try!(File::create("/vagga/root/etc/apk/repositories")
         .and_then(|mut f| write!(&mut f, "{}{}/main\n",
             mirror, version))
@@ -283,9 +334,13 @@ pub fn configure(distro: &mut Box<Distribution>, ctx: &mut Context,
     ver: &str)
     -> Result<(), StepError>
 {
+    let mirror = ctx.settings.alpine_mirror.clone()
+        .unwrap_or(choose_mirror());
     try!(distro.set(Distro {
         version: ver.to_string(),
+        mirror: mirror,
         base_setup: false,
+        apk_update: true,
     }));
     ctx.binary_ident = format!("{}-alpine-{}", ctx.binary_ident, ver);
     try!(ctx.add_cache_dir(Path::new("/etc/apk/cache"),
@@ -312,6 +367,39 @@ impl BuildStep for Alpine {
         try!(configure(&mut guard.distro, &mut guard.ctx, &self.0));
         if build {
             try!(guard.distro.bootstrap(&mut guard.ctx));
+        }
+        Ok(())
+    }
+    fn is_dependent_on(&self) -> Option<&str> {
+        None
+    }
+}
+
+impl BuildStep for AlpineRepo {
+    fn hash(&self, _cfg: &Config, hash: &mut Digest)
+        -> Result<(), VersionError>
+    {
+        if let Some(ref url) = self.url {
+            hash.field("url", url);
+        }
+        if let Some(ref branch) = self.branch {
+            hash.field("branch", branch);
+        }
+        hash.field("repo", &self.repo);
+        if let Some(ref alias) = self.alias {
+            hash.field("alias", alias);
+        }
+        Ok(())
+    }
+    fn build(&self, guard: &mut Guard, build: bool)
+        -> Result<(), StepError>
+    {
+        if build {
+            let ref mut ctx = guard.ctx;
+            try!(guard.distro.specific(|u: &mut Distro| {
+                try!(u.add_repo(ctx, &self));
+                Ok(())
+            }));
         }
         Ok(())
     }

--- a/src/builder/commands/alpine.rs
+++ b/src/builder/commands/alpine.rs
@@ -36,7 +36,7 @@ pub struct AlpineRepo {
     url: Option<String>,
     branch: Option<String>,
     repo: String,
-    alias: Option<String>,
+    tag: Option<String>,
 }
 
 impl Alpine {
@@ -51,7 +51,7 @@ impl AlpineRepo {
         .member("url", V::Scalar::new().optional())
         .member("branch", V::Scalar::new().optional())
         .member("repo", V::Scalar::new())
-        .member("alias", V::Scalar::new().optional())
+        .member("tag", V::Scalar::new().optional())
     }
 }
 
@@ -96,7 +96,7 @@ impl Distribution for Distro {
             url: Some(self.mirror.clone()),
             branch: branch.map(|x| x.to_string()),
             repo: repository.to_string(),
-            alias: None,
+            tag: None,
         };
         try!(self.add_alpine_repo(ctx, &alpine_repo));
         Ok(())
@@ -185,8 +185,8 @@ impl Distro {
         self.apk_update = true;
 
         let mut repo_line = String::new();
-        if let Some(ref alias) = repo.alias {
-            write!(&mut repo_line, "@{} ", alias).unwrap();
+        if let Some(ref tag) = repo.tag {
+            write!(&mut repo_line, "@{} ", tag).unwrap();
         }
         let url = repo.url.as_ref().unwrap_or(&self.mirror);
         let normalized_url = if !url.ends_with("/") {
@@ -406,7 +406,7 @@ impl BuildStep for AlpineRepo {
         hash.opt_field("url", &self.url);
         hash.opt_field("branch", &self.branch);
         hash.field("repo", &self.repo);
-        hash.opt_field("alias", &self.alias);
+        hash.opt_field("tag", &self.tag);
         Ok(())
     }
     fn build(&self, guard: &mut Guard, build: bool)

--- a/src/builder/commands/packaging.rs
+++ b/src/builder/commands/packaging.rs
@@ -24,6 +24,16 @@ impl BuildDeps {
     }
 }
 
+#[derive(Debug)]
+pub struct Repo(String);
+tuple_struct_decode!(Repo);
+
+impl Repo {
+    pub fn config() -> V::Scalar {
+        V::Scalar::new()
+    }
+}
+
 impl BuildStep for Install {
     fn hash(&self, _cfg: &Config, hash: &mut Digest)
         -> Result<(), VersionError>
@@ -65,6 +75,26 @@ impl BuildStep for BuildDeps {
                 }
             }
             try!(guard.distro.install(&mut guard.ctx, &self.0));
+        }
+        Ok(())
+    }
+    fn is_dependent_on(&self) -> Option<&str> {
+        None
+    }
+}
+
+impl BuildStep for Repo {
+    fn hash(&self, _cfg: &Config, hash: &mut Digest)
+        -> Result<(), VersionError>
+    {
+        hash.field("Repo", &self.0);
+        Ok(())
+    }
+    fn build(&self, guard: &mut Guard, build: bool)
+        -> Result<(), StepError>
+    {
+        if build {
+            try!(guard.distro.add_repo(&mut guard.ctx, &self.0));
         }
         Ok(())
     }

--- a/src/builder/distrib.rs
+++ b/src/builder/distrib.rs
@@ -29,6 +29,9 @@ pub trait Distribution: Any {
     /// Does distro-specific cleanup at the end of the build
     fn finish(&mut self, &mut Context) -> Result<(), String> { Ok(()) }
 
+    /// Adds repository
+    fn add_repo(&mut self, &mut Context, &str) -> Result<(), StepError>;
+
     /// Install normal packages
     fn install(&mut self, &mut Context, &[String]) -> Result<(), StepError>;
 
@@ -48,6 +51,11 @@ impl Distribution for Unknown {
     fn name(&self) -> &'static str { "unknown" }
     fn bootstrap(&mut self, _: &mut Context) -> Result<(), StepError> {
         unreachable!();
+    }
+    fn add_repo(&mut self, _: &mut Context, _repo: &str)
+        -> Result<(), StepError>
+    {
+        Err(StepError::NoDistro)
     }
     fn install(&mut self, _: &mut Context, _pkgs: &[String])
         -> Result<(), StepError>

--- a/src/config/builders.rs
+++ b/src/config/builders.rs
@@ -8,8 +8,9 @@ use builder::commands as cmd;
 
 use build_step::{Step, BuildStep};
 
-const COMMANDS: [&'static str; 43] = [
+const COMMANDS: &'static [&'static str] = &[
     "Alpine",
+    "AlpineRepo",
     "Ubuntu",
     "UbuntuRepo",
     "UbuntuRelease",
@@ -79,6 +80,7 @@ pub struct Copy {
 pub fn builder_validator<'x>() -> V::Enum<'x> {
     V::Enum::new()
     .option("Alpine", cmd::alpine::Alpine::config())
+    .option("AlpineRepo", cmd::alpine::AlpineRepo::config())
     .option("Ubuntu", cmd::ubuntu::Ubuntu::config())
     .option("UbuntuRelease", cmd::ubuntu::UbuntuRelease::config())
     .option("UbuntuRepo", cmd::ubuntu::UbuntuRepo::config())
@@ -144,6 +146,7 @@ fn decode_step<D: Decoder>(options: &[&str], index: usize, d: &mut D)
 {
     match options[index] {
         "Alpine" => step(cmd::alpine::Alpine::decode(d)),
+        "AlpineRepo" => step(cmd::alpine::AlpineRepo::decode(d)),
         "Ubuntu" => step(cmd::ubuntu::Ubuntu::decode(d)),
         "UbuntuRepo" => step(cmd::ubuntu::UbuntuRepo::decode(d)),
         "UbuntuRelease" => step(cmd::ubuntu::UbuntuRelease::decode(d)),

--- a/src/config/builders.rs
+++ b/src/config/builders.rs
@@ -17,6 +17,7 @@ const COMMANDS: &'static [&'static str] = &[
     "UbuntuPPA",
     "UbuntuUniverse",
     "AptTrust",
+    "Repo",
     "Install",
     "BuildDeps",
     "Git",
@@ -87,6 +88,7 @@ pub fn builder_validator<'x>() -> V::Enum<'x> {
     .option("UbuntuPPA", cmd::ubuntu::UbuntuPPA::config())
     .option("UbuntuUniverse", cmd::ubuntu::UbuntuUniverse::config())
     .option("AptTrust", cmd::ubuntu::AptTrust::config())
+    .option("Repo", cmd::packaging::Repo::config())
     .option("Install", cmd::packaging::Install::config())
     .option("BuildDeps", cmd::packaging::BuildDeps::config())
     .option("Container", cmd::subcontainer::Container::config())
@@ -153,6 +155,7 @@ fn decode_step<D: Decoder>(options: &[&str], index: usize, d: &mut D)
         "UbuntuPPA" => step(cmd::ubuntu::UbuntuPPA::decode(d)),
         "UbuntuUniverse" => step(cmd::ubuntu::UbuntuUniverse::decode(d)),
         "AptTrust" => step(cmd::ubuntu::AptTrust::decode(d)),
+        "Repo" => step(cmd::packaging::Repo::decode(d)),
         "Install" => step(cmd::packaging::Install::decode(d)),
         "BuildDeps" => step(cmd::packaging::BuildDeps::decode(d)),
         "Git" => step(cmd::vcs::Git::decode(d)),

--- a/tests/alpine.bats
+++ b/tests/alpine.bats
@@ -24,6 +24,15 @@ setup() {
     [[ $output = *"Error checking alpine version"* ]]
 }
 
+@test "alpine: Alpine repo" {
+    run vagga _build alpine-repo
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/alpine-repo)
+    [[ $link = ".roots/alpine-repo.a3bfac74/root" ]]
+    run vagga _run alpine-repo tini -h
+    [[ $output = *"tini (version 0.9.0)"* ]]
+}
+
 @test "alpine: Run echo command" {
     run vagga echo-cmd hello
     printf "%s\n" "${lines[@]}"

--- a/tests/alpine.bats
+++ b/tests/alpine.bats
@@ -24,15 +24,6 @@ setup() {
     [[ $output = *"Error checking alpine version"* ]]
 }
 
-@test "alpine: Alpine repo" {
-    run vagga _build alpine-repo
-    printf "%s\n" "${lines[@]}"
-    link=$(readlink .vagga/alpine-repo)
-    [[ $link = ".roots/alpine-repo.a3bfac74/root" ]]
-    run vagga _run alpine-repo tini -h
-    [[ $output = *"tini (version 0.9.0)"* ]]
-}
-
 @test "alpine: Run echo command" {
     run vagga echo-cmd hello
     printf "%s\n" "${lines[@]}"
@@ -100,4 +91,69 @@ setup() {
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-2]} = 6ea38cf8 ]]
     [[ ${lines[${#lines[@]}-1]} = 6ea38cf8bd751ac737a41c6e1ddb4b87a804f8e562c30064ec42941005b7bc6f ]]
+}
+
+@test "alpine: AlpineRepo minimal" {
+    run vagga _build alpine-repo
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/alpine-repo)
+    [[ $link = ".roots/alpine-repo.a3bfac74/root" ]]
+
+    [[ $(tail -n 1 ".vagga/alpine-repo/etc/apk/repositories") = *"/v3.4/community" ]]
+    repositories=($(sed "s/\/community/\/main/g" ".vagga/alpine-repo/etc/apk/repositories"))
+    # test that additional repository has the same mirror
+    [[ ${repositories[0]} = ${repositories[1]} ]]
+
+    run vagga _run alpine-repo tini -h
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+}
+
+@test "alpine: AlpineRepo full" {
+    run vagga _build alpine-repo-full
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/alpine-repo-full)
+    [[ $link = ".roots/alpine-repo-full.c7f46fee/root" ]]
+
+    [[ $(tail -n 1 ".vagga/alpine-repo-full/etc/apk/repositories") = \
+        "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" ]]
+
+    run vagga _run alpine-repo-full toilet Welcome
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ $output = *'m     m        ""#'* ]]
+}
+
+@test "alpine: Repo simple" {
+    run vagga _build repo-simple
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/repo-simple)
+    [[ $link = ".roots/repo-simple.8c9ad301/root" ]]
+
+    [[ $(tail -n 1 ".vagga/repo-simple/etc/apk/repositories") = *"/v3.4/community" ]]
+    repositories=($(sed "s/\/community/\/main/g" ".vagga/repo-simple/etc/apk/repositories"))
+    # test that additional repository has the same mirror
+    [[ ${repositories[0]} = ${repositories[1]} ]]
+
+    run vagga _run repo-simple tini -h
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+}
+
+@test "alpine: Repo with branch" {
+    run vagga _build repo-with-branch
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/repo-with-branch)
+    [[ $link = ".roots/repo-with-branch.de239880/root" ]]
+
+    [[ $(tail -n 1 ".vagga/repo-with-branch/etc/apk/repositories") = *"/edge/testing" ]]
+    repositories=($(sed "s/\/edge\/testing/\/v3.4\/main/g" ".vagga/repo-with-branch/etc/apk/repositories"))
+    # test that additional repository has the same mirror
+    echo ${repositories[*]}
+    [[ ${repositories[0]} = ${repositories[1]} ]]
+
+    run vagga _run repo-with-branch toilet Welcome
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ $output = *'m     m        ""#'* ]]
 }

--- a/tests/alpine.bats
+++ b/tests/alpine.bats
@@ -113,7 +113,7 @@ setup() {
     run vagga _build alpine-repo-full
     printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/alpine-repo-full)
-    [[ $link = ".roots/alpine-repo-full.c7f46fee/root" ]]
+    [[ $link = ".roots/alpine-repo-full.ce345923/root" ]]
 
     [[ $(tail -n 1 ".vagga/alpine-repo-full/etc/apk/repositories") = \
         "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" ]]

--- a/tests/alpine/vagga.yaml
+++ b/tests/alpine/vagga.yaml
@@ -1,12 +1,5 @@
 containers:
 
-  alpine-repo:
-    setup:
-    - !Alpine v3.4
-    - !AlpineRepo
-      repo: community
-    - !Install [tini]
-
   v34-calc:
     setup:
     - !Alpine v3.4
@@ -51,6 +44,35 @@ containers:
     - !Text
       /etc/subuid: ""
       /etc/subgid: ""
+
+  alpine-repo:
+    setup:
+    - !Alpine v3.4
+    - !AlpineRepo
+      repo: community
+    - !Install [tini]
+
+  alpine-repo-full:
+    setup:
+    - !Alpine v3.4
+    - !AlpineRepo
+      url: http://dl-cdn.alpinelinux.org/alpine/
+      branch: edge
+      repo: testing
+      alias: testing
+    - !Install [toilet@testing]
+
+  repo-simple:
+    setup:
+    - !Alpine v3.4
+    - !Repo community
+    - !Install [tini]
+
+  repo-with-branch:
+    setup:
+    - !Alpine v3.4
+    - !Repo edge/testing
+    - !Install [toilet]
 
 commands:
   echo-cmd: !Command

--- a/tests/alpine/vagga.yaml
+++ b/tests/alpine/vagga.yaml
@@ -59,7 +59,7 @@ containers:
       url: http://dl-cdn.alpinelinux.org/alpine/
       branch: edge
       repo: testing
-      alias: testing
+      tag: testing
     - !Install [toilet@testing]
 
   repo-simple:

--- a/tests/alpine/vagga.yaml
+++ b/tests/alpine/vagga.yaml
@@ -1,5 +1,12 @@
 containers:
 
+  alpine-repo:
+    setup:
+    - !Alpine v3.4
+    - !AlpineRepo
+      repo: community
+    - !Install [tini]
+
   v34-calc:
     setup:
     - !Alpine v3.4

--- a/tests/ubuntu.bats
+++ b/tests/ubuntu.bats
@@ -121,3 +121,61 @@ setup() {
     link=$(readlink .vagga/ppa)
     [[ $link = ".roots/ppa.73b33181/root" ]]
 }
+
+@test "ubuntu: UbuntuRepo minimal" {
+    run vagga _build ubuntu-repo-minimal
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/ubuntu-repo-minimal)
+    [[ $link = ".roots/ubuntu-repo-minimal.c01e9336/root" ]]
+
+    repo_line=$(cat ".vagga/ubuntu-repo-minimal/etc/apt/sources.list.d/84fc0152-xenial.list")
+    [[ $repo_line = *" xenial universe" ]]
+
+    run vagga _run ubuntu-repo-minimal /usr/games/cowsay "Have you mooed today?"
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ $output = *"Have you mooed today?"* ]]
+}
+
+@test "ubuntu: UbuntuRepo full" {
+    run vagga _build ubuntu-repo-full
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/ubuntu-repo-full)
+    [[ $link = ".roots/ubuntu-repo-full.dfc21695/root" ]]
+
+    repo_line=$(cat ".vagga/ubuntu-repo-full/etc/apt/sources.list.d/3276db2a-vagga.list")
+    [[ $repo_line = "deb [trusted=yes] http://ubuntu.zerogw.com vagga main" ]]
+
+    run vagga _run ubuntu-repo-full vagga --version
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ $output = "v0.6.1" ]]
+}
+
+@test "ubuntu: Repo simple" {
+    run vagga _build repo-simple
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/repo-simple)
+    [[ $link = ".roots/repo-simple.b510b875/root" ]]
+
+    repo_line=$(cat ".vagga/repo-simple/etc/apt/sources.list.d/84fc0152-xenial.list")
+    [[ $repo_line = *" xenial universe" ]]
+
+    run vagga _run repo-simple banner Wonderful
+    printf "%s\n" "${lines[@]}"
+    [[ $output = "#     #"* ]]
+}
+
+@test "ubuntu: Repo with suite" {
+    run vagga _build repo-with-suite
+    printf "%s\n" "${lines[@]}"
+    link=$(readlink .vagga/repo-with-suite)
+    [[ $link = ".roots/repo-with-suite.883e5d19/root" ]]
+
+    repo_line=$(cat ".vagga/repo-with-suite/etc/apt/sources.list.d/84fc0152-xenial.list")
+    [[ $repo_line = *" xenial universe" ]]
+
+    run vagga _run repo-with-suite banner Wonderful
+    printf "%s\n" "${lines[@]}"
+    [[ $output = "#     #"* ]]
+}

--- a/tests/ubuntu/vagga.yaml
+++ b/tests/ubuntu/vagga.yaml
@@ -35,6 +35,35 @@ containers:
     - !BuildDeps [file]  # a dependency of checkinstall
     - !Install [checkinstall]
 
+  ubuntu-repo-minimal:
+    setup:
+    - !Ubuntu xenial
+    - !UbuntuRepo
+      components: [universe]
+    - !Install [cowsay]
+
+  ubuntu-repo-full:
+    setup:
+    - !Ubuntu xenial
+    - !UbuntuRepo
+      url: http://ubuntu.zerogw.com
+      suite: vagga
+      components: [main]
+      trusted: true
+    - !Install [vagga=0.6.1-1]
+
+  repo-simple:
+    setup:
+    - !Ubuntu xenial
+    - !Repo universe
+    - !Install [sysvbanner]
+
+  repo-with-suite:
+    setup:
+    - !Ubuntu xenial
+    - !Repo xenial/universe
+    - !Install [sysvbanner]
+
 commands:
   echo-cmd: !Command
     container: trusty


### PR DESCRIPTION
Doubt about naming of `alias` option for `AlpineRepo` command. In the [Alpine Wiki](https://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management) they call it as `pin` or `tag`.