### PR TITLE
First implementation of options support (#338)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,7 @@ dependencies = [
  "anymap 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "argparse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bzip2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 0.6.83 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -82,6 +83,17 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "docopt"
+version = "0.6.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +150,11 @@ dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
@@ -341,6 +358,11 @@ dependencies = [
  "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tar"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ bzip2 = "0.3.0"
 net2 = "0.2.23"
 humantime = "1.0.0"
 quick-error = "1.1.0"
+docopt = "0.6.83"
 
 [dependencies.quire]
 git = "git://github.com/tailhook/rust-quire"

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -134,25 +134,68 @@ These parameters work for both kinds of commands:
                 py.test --redis-port "$VAGGAOPT_REDIS_PORT" $VAGGAOPT_TESTS
 
    As you might have noticed, options are passed in environment variables
-   prefixed with ``VAGGAOPT_``. Your scripts are free to use them however
-   makes sense for your application.
+   prefixed with ``VAGGAOPT_`` and ``VAGGACLI_`` (see below).
+   Your scripts are free to use them however makes sense for your application.
 
    .. note:: This setting overrides :opt:`accepts-arguments`
 
-   Some shell patterns:
+   Every argument is translated into two variables:
 
-   1. Propagate a flag::
+   * ``VAGGAOPT_ARG`` -- has the raw value of the argument, for boolean flags
+     it contains either ``true`` or nothing, for repeatable flags it contains
+     a number of occurences
+   * ``VAGGACLI_ARG`` -- has a canonical representation of an argument, this
+     includes option name and all needed escaping to represent multiple
+     command line arguments
+
+   The ``ARG`` is usually a long name of the option if exists, or short
+   name otherwise. For positional arguments it's argument name. It's always
+   uppercased and has ``-`` replaced with ``_``
+
+   There are few shortcommings of both kinds:
+
+   1. ``VAGGAOPT_`` can't represent list of arguments that can contain
+      spaces. So it can't be used for list of file names in the general
+      case.
+   2. ``VAGGACLI_`` contains escaped versions of arguments so requires
+      using ``eval`` to make proper argument list from it
+
+   Some shell patterns using ``VAGGAOPT_``:
+
+   1. To propagate a flag, use either one::
 
         somecmd ${VAGGAOPT_FLAG:+--flag}
+        somecmd $VAGGACLI_FLAG
 
-   2. Optionally pass a value to a command::
+   2. To optionally pass a value to a command, use either one (note the
+      implications of eval in the second command)::
 
         somecmd ${VAGGAOPT_VALUE:+--value} $VAGGAOPT_VALUE
+        eval somecmd $VAGGACLI_VALUE
 
-   3. Pass list of commands each prefixed with an ``--test=`` (bash only)::
+      To overcome limitations of eval, for example if you need to expand
+      ``$(hostname)`` in the command, you can use the following snippet::
 
-        tests=($VAGGAOPT_TESTS)
-        somecmd ${tests[@]/#/--test=}
+        eval printf "'%s\0'" $VAGGACLI_VALUE | xargs -0 somecmd -H$(hostname)
+
+   3. To pass a list of commands each prefixed with a ``--test=``, use either
+      one::
+
+        # any shell (but ugly)
+        eval printf "'%s\0'" $VAGGACLI_TESTS | sed -z 's/^/--test=/' | xargs -0 somecmd
+      ::
+
+        # bash only
+        eval "tests=($VAGGACLI_TESTS)"
+        somecmd "${tests[@]/#/--test=}"
+
+      (Note for some ``sed`` implementations you need to omit ``-z`` flag)
+
+      This works if you have argument like ``vagga test <tests>...``. However,
+      if your vagga command-line is ``vagga test --test=<name>...`` use the
+      following instead::
+
+        eval somecmd $VAGGACLI_TEST
 
 .. _docopt: http://docopt.org/
 

--- a/src/config/command.rs
+++ b/src/config/command.rs
@@ -52,7 +52,8 @@ pub struct CommandInfo {
     pub banner_delay: Option<u32>,
     pub epilog: Option<String>,
     pub pass_tcp_socket: Option<String>,
-    pub prerequisites: Vec<String>,  // Only for toplevel
+    pub prerequisites: Vec<String>,
+    pub options: Option<String>,  // Only for toplevel
     pub expect_inotify_limit: Option<usize>,
 
     // Command
@@ -80,6 +81,7 @@ pub struct SuperviseInfo {
     pub banner_delay: Option<u32>,
     pub epilog: Option<String>,
     pub prerequisites: Vec<String>,
+    pub options: Option<String>,  // Only for toplevel
     pub expect_inotify_limit: Option<usize>,
 
     // Supervise
@@ -203,7 +205,7 @@ fn run_fields<'a>(cmd: V::Structure, network: bool) -> V::Structure {
     return cmd;
 }
 
-fn command_fields<'a>(mut cmd: V::Structure, _toplevel: bool) -> V::Structure
+fn command_fields<'a>(mut cmd: V::Structure, toplevel: bool) -> V::Structure
 {
     cmd = cmd
         .member("description", V::Scalar::new().optional())
@@ -214,6 +216,9 @@ fn command_fields<'a>(mut cmd: V::Structure, _toplevel: bool) -> V::Structure
         .member("pass_tcp_socket", V::Scalar::new().optional())
         .member("expect_inotify_limit", V::Scalar::new().optional())
         .member("prerequisites", V::Sequence::new(V::Scalar::new()));
+    if toplevel {
+        cmd = cmd.member("options", V::Scalar::new().optional());
+    }
     return cmd;
 }
 

--- a/src/launcher/mod.rs
+++ b/src/launcher/mod.rs
@@ -30,6 +30,7 @@ pub mod system;
 mod network;
 mod socket;
 mod volumes;
+mod options;
 mod prerequisites;
 
 

--- a/src/launcher/options.rs
+++ b/src/launcher/options.rs
@@ -1,0 +1,58 @@
+use std::ascii::AsciiExt;
+use std::collections::HashMap;
+
+use docopt::{Docopt, Value, ArgvMap};
+
+use launcher::user::ArgError;
+
+
+pub fn parse_docopts(description: &Option<String>,
+    original_text: &str, extra_text: &str,
+    cmd: &str, mut args: Vec<String>)
+    -> Result<(HashMap<String, String>, ArgvMap), ArgError>
+{
+    args.insert(0, "vagga".to_string());
+    args.insert(1, cmd.to_string());
+    let docopt = format!("\
+            {}\n\
+            \n\
+            {}\n\
+            {}\n",
+        description.as_ref().unwrap_or(&format!("vagga {}", cmd)),
+        original_text,
+        extra_text);
+    let opt = try!(Docopt::new(docopt)
+        .map_err(|e| format!("Error parsing `options` in command {:?}: {}",
+                             cmd, e))
+        .map_err(ArgError::Error))
+        .argv(args);
+    let parsed = match opt.parse() {
+        Ok(parsed) => parsed,
+        Err(ref e) if e.fatal() => {
+            return Err(ArgError::Error(format!("{}", e)));
+        }
+        Err(ref e) => {
+            println!("{}", e);
+            return Err(ArgError::Exit(0));
+        }
+    };
+    let mut env = HashMap::new();
+    for (key, value) in parsed.map.iter() {
+        let key = key
+            .trim_left_matches('-').trim_left_matches('<')
+            .trim_right_matches('>');
+        let env_var = format!("VAGGAOPT_{}",
+            key.replace("-", "_").to_ascii_uppercase());
+        match *value {
+            Value::Switch(false) => env.insert(env_var, "".to_string()),
+            Value::Switch(true) => env.insert(env_var, "true".to_string()),
+            Value::Counted(0) => env.insert(env_var, "".to_string()),
+            Value::Counted(v) => env.insert(env_var, format!("{}", v)),
+            Value::Plain(None) => env.insert(env_var, "".to_string()),
+            Value::Plain(Some(ref x))
+            => env.insert(env_var, x.to_string()),
+            Value::List(ref lst) => env.insert(env_var, lst.join(" ")),
+        };
+    }
+    Ok((env, parsed))
+}

--- a/src/launcher/options.rs
+++ b/src/launcher/options.rs
@@ -1,9 +1,37 @@
+use std::fmt;
+use std::fmt::Write;
+use std::iter::repeat;
 use std::ascii::AsciiExt;
 use std::collections::HashMap;
 
 use docopt::{Docopt, Value, ArgvMap};
 
 use launcher::user::ArgError;
+
+struct Escaped<T: AsRef<str>>(T);
+
+impl<T: AsRef<str>> fmt::Display for Escaped<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let data = self.0.as_ref();
+        if data.len() == 0 {
+            write!(fmt, "''")
+        } else if !data.contains(|c: char| !(c.is_alphanumeric() ||
+            matches!(c, '@'|'%'|'+'|'='|':'|','|'.'|'/'|'-')))
+        {
+            write!(fmt, "{}", data)
+        } else {
+            try!(fmt.write_str("'"));
+            for c in data.chars() {
+                if c == '\'' {
+                    try!(fmt.write_str(r#"'"'"'"#));
+                } else {
+                    try!(write!(fmt, "{}", c));
+                }
+            }
+            fmt.write_str("'")
+        }
+    }
+}
 
 
 pub fn parse_docopts(description: &Option<String>,
@@ -37,22 +65,70 @@ pub fn parse_docopts(description: &Option<String>,
         }
     };
     let mut env = HashMap::new();
-    for (key, value) in parsed.map.iter() {
-        let key = key
+    for (orig_key, value) in parsed.map.iter() {
+        let key = orig_key
             .trim_left_matches('-').trim_left_matches('<')
             .trim_right_matches('>');
         let env_var = format!("VAGGAOPT_{}",
             key.replace("-", "_").to_ascii_uppercase());
+        let env_var2 = format!("VAGGACLI_{}",
+            key.replace("-", "_").to_ascii_uppercase());
         match *value {
-            Value::Switch(false) => env.insert(env_var, "".to_string()),
-            Value::Switch(true) => env.insert(env_var, "true".to_string()),
-            Value::Counted(0) => env.insert(env_var, "".to_string()),
-            Value::Counted(v) => env.insert(env_var, format!("{}", v)),
-            Value::Plain(None) => env.insert(env_var, "".to_string()),
-            Value::Plain(Some(ref x))
-            => env.insert(env_var, x.to_string()),
-            Value::List(ref lst) => env.insert(env_var, lst.join(" ")),
-        };
+            Value::Switch(false) => {
+                env.insert(env_var, "".to_string());
+                env.insert(env_var2, "".to_string());
+            }
+            Value::Switch(true) => {
+                env.insert(env_var, "true".to_string());
+                env.insert(env_var2, orig_key.to_string());
+            }
+            Value::Counted(0) => {
+                env.insert(env_var, "".to_string());
+                env.insert(env_var2, "".to_string());
+            }
+            Value::Counted(v) => {
+                env.insert(env_var, format!("{}", v));
+                if orig_key.starts_with("--") {  // long option
+                    env.insert(env_var2,
+                        repeat(&orig_key[..]).take(v as usize)
+                            .collect::<Vec<_>>().join(" "));
+                } else {  // short option
+                    env.insert(env_var2,
+                        format!("-{}",
+                            repeat(&orig_key[1..2]).take(v as usize)
+                            .collect::<String>()));
+                }
+            }
+            Value::Plain(None) => {
+                env.insert(env_var, "".to_string());
+                env.insert(env_var2, "".to_string());
+            }
+            Value::Plain(Some(ref x)) => {
+                env.insert(env_var, x.to_string());
+                if orig_key.starts_with('-') {
+                    env.insert(env_var2, format!("{} {}", orig_key,
+                        Escaped(x)));
+                } else {
+                    env.insert(env_var2, format!("{}", Escaped(x)));
+                }
+            }
+            Value::List(ref lst) => {
+                if lst.len() > 0 {
+                    env.insert(env_var, lst.join(" "));
+                    let mut buf = String::new();
+                    if orig_key.starts_with('-') {
+                        write!(&mut buf, "{}", orig_key).unwrap();
+                    }
+                    for value in lst {
+                        write!(&mut buf, " {}", Escaped(value)).unwrap();
+                    }
+                    env.insert(env_var2, buf);
+                } else {
+                    env.insert(env_var, "".to_string());
+                    env.insert(env_var2, "".to_string());
+                }
+            }
+        }
     }
     Ok((env, parsed))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ extern crate flate2;
 extern crate xz2;
 extern crate bzip2;
 extern crate net2;
+extern crate docopt;
 extern crate humantime;
 #[macro_use] extern crate matches;
 #[macro_use] extern crate mopa;

--- a/src/wrapper/setup.rs
+++ b/src/wrapper/setup.rs
@@ -314,6 +314,8 @@ pub fn get_environment(settings: &Settings, container: &Container,
     for (k, v) in env::vars() {
         if k.starts_with("VAGGAENV_") {
             result.insert(k[9..].to_string(), v);
+        } else if k.starts_with("VAGGAOPT_") {
+            result.insert(k, v);
         }
     }
     return Ok(result);

--- a/src/wrapper/setup.rs
+++ b/src/wrapper/setup.rs
@@ -314,7 +314,7 @@ pub fn get_environment(settings: &Settings, container: &Container,
     for (k, v) in env::vars() {
         if k.starts_with("VAGGAENV_") {
             result.insert(k[9..].to_string(), v);
-        } else if k.starts_with("VAGGAOPT_") {
+        } else if k.starts_with("VAGGAOPT_") || k.starts_with("VAGGACLI_") {
             result.insert(k, v);
         }
     }

--- a/tests/generic.bats
+++ b/tests/generic.bats
@@ -375,7 +375,7 @@ setup() {
     printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/environ)
     [[ $link = ".roots/environ.4ed6a479/root" ]]
-    
+
     [[ $(vagga _run environ env | grep 'EDITOR=') = "EDITOR=vi" ]]
     [[ $(vagga _run environ env | grep 'SHELL=') = "SHELL=/bin/bash" ]]
 
@@ -386,4 +386,57 @@ setup() {
     [[ $(VAGGAENV_EDITOR=pico EDITOR=nano vagga --use-env EDITOR which-editor) = "nano" ]]
 
     [[ $(VAGGAENV_EDITOR=pico EDITOR=nano vagga --use-env EDITOR -E EDITOR=emacs which-editor) = "emacs" ]]
+}
+
+@test "generic: Argument parsing for supervise" {
+    run sh -c 'vagga args -Fhello --second "world"  | sort'
+    printf "%s\n" "${lines[@]}"
+    [[ ${lines[${#lines[@]}-2]} = "hello" ]]
+    [[ ${lines[${#lines[@]}-1]} = "world" ]]
+
+    run sh -c 'vagga args --first=x --second="y" | sort'
+    printf "%s\n" "${lines[@]}"
+    [[ ${lines[${#lines[@]}-2]} = "x" ]]
+    [[ ${lines[${#lines[@]}-1]} = "y" ]]
+}
+
+@test "generic: Argument parsing for normal command" {
+    run vagga cmdargs -vvvv --verbose
+    printf "%s\n" "${lines[@]}"
+    # ensure arguments is not passed directly
+    [[ ${lines[${#lines[@]}-2]} = "Args:" ]]
+    [[ ${lines[${#lines[@]}-1]} = "Verbosity: 5" ]]
+}
+
+@test "generic: Help with 'options'" {
+    run vagga cmdargs --help
+    printf "%s\n" "${lines[@]}"
+    [[ "$status" -eq 0 ]]
+
+    run vagga args --help
+    printf "%s\n" "${lines[@]}"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "generic: Bad arguments for command with 'options'" {
+    run vagga args --bad-arg
+    printf "%s\n" "${lines[@]}"
+    [[ "$status" -eq 121 ]]
+    [[ ${lines[${#lines[@]}-2]} = "Unknown flag: '--bad-arg'" ]]
+    [[ ${lines[${#lines[@]}-1]} = "Usage: vagga args [options]" ]]
+
+    run vagga cmdargs --bad-arg
+    printf "%s\n" "${lines[@]}"
+    [[ "$status" -eq 121 ]]
+    [[ ${lines[${#lines[@]}-1]} = "Usage: vagga cmdargs [options]" ]]
+
+    run vagga args extra-arg
+    printf "%s\n" "${lines[@]}"
+    [[ "$status" -eq 121 ]]
+    [[ ${lines[${#lines[@]}-1]} = "Usage: vagga args [options]" ]]
+
+    run vagga cmdargs extra-arg
+    printf "%s\n" "${lines[@]}"
+    [[ "$status" -eq 121 ]]
+    [[ ${lines[${#lines[@]}-1]} = "Usage: vagga cmdargs [options]" ]]
 }

--- a/tests/generic/vagga.yaml
+++ b/tests/generic/vagga.yaml
@@ -231,6 +231,37 @@ commands:
           echo hello
           sleep 0.1
 
+
+  args: !Supervise
+    description: Test of arg parsing
+    options: |
+      Usage: vagga args [options]
+
+      Options:
+        -F, --first <txt>  First process' text
+        --second <txt>     Second process' text
+    children:
+      second-line: !Command
+        container: busybox
+        run: |
+          echo $VAGGAOPT_FIRST
+      first-line: !Command
+        container: busybox
+        run: |
+          echo $VAGGAOPT_SECOND
+
+  cmdargs: !Command
+    description: Test of arg parsing
+    container: busybox
+    options: |
+      Usage: vagga cmdargs [options]
+
+      Options:
+        -v, --verbose ...  Increase pseudo-verbosity
+    run: |
+      echo Args: "$@"
+      echo Verbosity: "$VAGGAOPT_VERBOSE"
+
   tagged: !Supervise
     children:
       first: !Command


### PR DESCRIPTION
This is the initial implementation. Missing pieces:

* [x] `VAGGAOPT_` have unescaped versions of arguments, so it's basically impossible to pass a list of filenames which can contain spaces
* [x] `VAGGAOPT_` passes raw values, so it sometimes hard to reproduce original command-line, for example `-p 1 -p 2`, would pass `VAGGAOPT_P="1 2"`, or `-vvv` makes `VAGGAOPT_VERBOSITY=3`
* [x] Doc: description of specifics of how options are converted to environment variables is missing
* [ ] Previously it was possible to append `--no-build` and similar options to the end of supervise command, I've implemented just `--only` and `--exclude` for now. Probably it will stay like this (it's possible to specify them earlier like `vagga --no-build cmd`)