### PR TITLE
Fixed _create_netns command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ script:
 - |
   set -ex
   if [[ $TRAVIS_OS_NAME != osx ]]; then
+    vagga _create_netns
     tests=($(echo $TESTS))
     for test in ${tests[@]}; do
       if [[ $test = cargo ]]; then


### PR DESCRIPTION
I would like to test running commands inside network namespace. In order to do that we need to mount namespace files into container. But vagga search namespace files inside `/tmp` directory which can be read-only inside container. What do you think about that?