### PR TITLE
Fix php in alpine 3.5

### DIFF
--- a/docs/build_commands.rst
+++ b/docs/build_commands.rst
@@ -507,7 +507,14 @@ runtime:
     - !Ubuntu xenial
     - !ComposerConfig
       install_runtime: false
-      runtime_exe: hhvm
+      runtime_exe: /usr/bin/hhvm
+
+.. note:: When setting the ``runtime_exe`` option, be sure to specify the full
+   path of the binary (e.g ``/usr/bin/hhvm``).
+
+.. note:: Vagga will try to create a symlink from ``runtime_exe`` into
+   ``/usr/bin/php``. If that location already exists, Vagga will **not**
+   overwrite it.
 
 Note that you will have to manually `install hhvm`_ and set the ``include_path``:
 
@@ -515,17 +522,38 @@ Note that you will have to manually `install hhvm`_ and set the ``include_path``
 
     setup:
     - !Ubuntu xenial
-    - !UbuntuUniverse
-    - !AptTrust keys: ["hhvm apt key here"]
-    - !UbuntuRepo
-      url: http://dl.hhvm.com/ubuntu
-      suite: xenial
-      components: [main]
+    - !Repo universe
     - !Install [hhvm]
     - !ComposerConfig
       install_runtime: false
-      runtime_exe: hhvm
-    - !Sh echo '.:/usr/local/lib/composer' >> /etc/hhvm/php.ini
+      runtime_exe: /usr/bin/hhvm
+    - !Sh echo 'include_path=.:/usr/local/lib/composer' >> /etc/hhvm/php.ini ❶
+    environ:
+      HHVM_REPO_CENTRAL_PATH: /run/hhvm.hhbc ❷
+
+* ❶ -- setup ``include_path`` in hhvm config
+* ❷ -- tell hhvm to store the build cache database in a writeable directory
+
+Alpine v3.5 added support for php7 in their "community" repository while keeping
+php5 as the default runtime. In order to use php7, you have to specify all the
+packages required by composer (and any other php packages you may need):
+
+.. code-block:: yaml
+
+    setup:
+    - !Alpine v3.5
+    - !Repo community
+    - !Install
+      - php7
+      - php7-openssl
+      - php7-phar
+      - php7-json
+      - php7-pdo
+      - php7-dom
+      - php7-zip
+    - !ComposerConfig
+      install_runtime: false
+      runtime_exe: /usr/bin/php7
 
 
 .. note:: Composer executable and additional utilities (like

--- a/docs/build_steps.rst
+++ b/docs/build_steps.rst
@@ -1400,7 +1400,7 @@ PHP/Composer Commands
 
       - !ComposerConfig
         install_runtime: false
-        runtime_exe: hhvm
+        runtime_exe: /usr/bin/hhvm
       - !ComposerInstall [phpunit/phpunit]
 
    .. note:: Every time :step:`ComposerConfig` is specified, options are
@@ -1412,7 +1412,10 @@ PHP/Composer Commands
    All options:
 
    runtime_exe
-        (default ``php``) The command to use for running Composer.
+        (default ``/usr/bin/php``) The command to use for running Composer. When
+        setting this option, be sure to specify the full path for the binary. A
+        symlink to the provided value will be created at ``/usr/bin/php`` if it
+        not exists, otherwise, ``/usr/bin/php`` will remain the same.
 
    install_runtime
         (default ``true``) Whether to install the default runtime (php)

--- a/src/builder/commands/alpine.rs
+++ b/src/builder/commands/alpine.rs
@@ -215,10 +215,8 @@ impl Distro {
 
         if current_version < version_with_php5 {
             vec!("php")
-        } else if current_version == version_with_php5 {
-            vec!("php5")
         } else {
-            vec!("php7")
+            vec!("php5")
         }
     }
 
@@ -231,15 +229,10 @@ impl Distro {
                 "php", "php-cli", "php-openssl", "php-phar",
                 "php-json", "php-pdo", "php-dom", "php-zip"
             )
-        } else if current_version == version_with_php5 {
+        } else {
             vec!(
                 "php5", "php5-cli", "php5-openssl", "php5-phar",
                 "php5-json", "php5-pdo", "php5-dom", "php5-zip"
-            )
-        } else {
-            vec!(
-                "php7", "php7-cli", "php7-openssl", "php7-phar",
-                "php7-json", "php7-pdo", "php7-dom", "php7-zip"
             )
         }
     }

--- a/src/builder/packages.rs
+++ b/src/builder/packages.rs
@@ -32,7 +32,7 @@ pub enum Package {
     NodeJsDev,
     Npm,
 
-    Php,
+    Php,        // not build dep
     PhpDev,
     Composer,
 

--- a/tests/composer.bats
+++ b/tests/composer.bats
@@ -225,5 +225,5 @@ teardown() {
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer 1.3.0" ]]
     link=$(readlink .vagga/hhvm-ubuntu-xenial)
-    [[ $link = ".roots/hhvm-ubuntu-xenial.246bdda3/root" ]]
+    [[ $link = ".roots/hhvm-ubuntu-xenial.1664cbd2/root" ]]
 }

--- a/tests/composer.bats
+++ b/tests/composer.bats
@@ -61,6 +61,30 @@ teardown() {
     [[ $link = ".roots/php-ubuntu-precise.d34c18db/root" ]]
 }
 
+@test "composer: php alpine 3.5" {
+    run vagga _run php-alpine-3_5 laravel --version
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ ${lines[${#lines[@]}-1]} = "Laravel Installer 1.3.0" ]]
+    link=$(readlink .vagga/php-alpine-3_5)
+    [[ $link = ".roots/php-alpine-3_5.9a42a892/root" ]]
+}
+
+@test "composer: php alpine 3.5 php7" {
+    run vagga _run php-alpine-3_5-php7 php --version
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ ${lines[${#lines[@]}-3]} = "PHP 7.0.14 (cli)"* ]]
+
+    run vagga _run php-alpine-3_5-php7 laravel --version
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ ${lines[${#lines[@]}-1]} = "Laravel Installer 1.3.0" ]]
+
+    link=$(readlink .vagga/php-alpine-3_5-php7)
+    [[ $link = ".roots/php-alpine-3_5-php7.ec53d4dc/root" ]]
+}
+
 @test "composer: php alpine 3.4" {
     run vagga _run php-alpine-3_4 laravel --version
     printf "%s\n" "${lines[@]}"

--- a/tests/composer.bats
+++ b/tests/composer.bats
@@ -82,7 +82,7 @@ teardown() {
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer 1.3.0" ]]
 
     link=$(readlink .vagga/php-alpine-3_5-php7)
-    [[ $link = ".roots/php-alpine-3_5-php7.ec53d4dc/root" ]]
+    [[ $link = ".roots/php-alpine-3_5-php7.6dd390c2/root" ]]
 }
 
 @test "composer: php alpine 3.4" {
@@ -112,7 +112,31 @@ teardown() {
     [[ $link = ".roots/php-alpine-3_2.14b46cd2/root" ]]
 }
 
-@test "composer: php ComposerDependencies" {
+@test "composer: php ComposerDependencies alpine 3.5" {
+    run vagga _run php-composer-deps-alpine-3_5 laravel --version
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ ${lines[${#lines[@]}-1]} = "Laravel Installer version 1.3.0" ]]
+    link=$(readlink .vagga/php-composer-deps-alpine-3_5)
+    [[ $link = ".roots/php-composer-deps-alpine-3_5.6c42be15/root" ]]
+}
+
+@test "composer: php ComposerDependencies alpine 3.5 php7" {
+    run vagga _run php-alpine-3_5-php7 php --version
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ ${lines[${#lines[@]}-3]} = "PHP 7.0.14 (cli)"* ]]
+
+    run vagga _run php-composer-deps-alpine-3_5-php7 laravel --version
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ ${lines[${#lines[@]}-1]} = "Laravel Installer version 1.3.0" ]]
+
+    link=$(readlink .vagga/php-composer-deps-alpine-3_5-php7)
+    [[ $link = ".roots/php-composer-deps-alpine-3_5-php7.757fec76/root" ]]
+}
+
+@test "composer: php ComposerDependencies alpine 3.4" {
     run vagga _run php-composer-deps laravel --version
     printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]

--- a/tests/composer/vagga.yaml
+++ b/tests/composer/vagga.yaml
@@ -39,6 +39,33 @@ containers:
     - !Install [php5-cgi]
     - !ComposerInstall ["nette/tester:1.7.0"]
 
+  php-alpine-3_5:
+    setup:
+    - !Alpine v3.5
+    - !ComposerInstall ["laravel/installer:1.3.0"]
+
+  php-alpine-3_5-php7:
+    setup:
+    - !Alpine v3.5
+    - !Repo community
+    - !Install
+      - bash
+      - php7
+      - php7-openssl
+      - php7-phar
+      - php7-json
+      - php7-pdo
+      - php7-dom
+      - php7-zip
+    - !Cmd
+      - /bin/ln
+      - -s
+      - /usr/bin/php7
+      - /usr/bin/php
+    - !ComposerConfig
+      install_runtime: false
+    - !ComposerInstall ["laravel/installer:1.3.0"]
+
   php-alpine-3_4:
     setup:
     - !Alpine v3.4

--- a/tests/composer/vagga.yaml
+++ b/tests/composer/vagga.yaml
@@ -150,6 +150,7 @@ containers:
     - !Install [hhvm]
     - !ComposerConfig
       install_runtime: false
+      runtime_exe: /usr/bin/hhvm
     - !Sh echo 'include_path=.:/usr/local/lib/composer' >> /etc/hhvm/php.ini
     - !ComposerInstall ["laravel/installer:1.3.0"]
     environ:

--- a/tests/composer/vagga.yaml
+++ b/tests/composer/vagga.yaml
@@ -57,13 +57,9 @@ containers:
       - php7-pdo
       - php7-dom
       - php7-zip
-    - !Cmd
-      - /bin/ln
-      - -s
-      - /usr/bin/php7
-      - /usr/bin/php
     - !ComposerConfig
       install_runtime: false
+      runtime_exe: /usr/bin/php7
     - !ComposerInstall ["laravel/installer:1.3.0"]
 
   php-alpine-3_4:
@@ -80,6 +76,29 @@ containers:
     setup:
     - !Alpine v3.2
     - !ComposerInstall ["laravel/installer:1.3.0"]
+
+  php-composer-deps-alpine-3_5:
+    setup:
+    - !Alpine v3.5
+    - !ComposerDependencies { dev: false }
+
+  php-composer-deps-alpine-3_5-php7:
+    setup:
+    - !Alpine v3.5
+    - !Repo community
+    - !Install
+      - bash
+      - php7
+      - php7-openssl
+      - php7-phar
+      - php7-json
+      - php7-pdo
+      - php7-dom
+      - php7-zip
+    - !ComposerConfig
+      install_runtime: false
+      runtime_exe: /usr/bin/php7
+    - !ComposerDependencies { dev: false }
 
   php-composer-deps:
     setup:


### PR DESCRIPTION
This pull request fixes php installation when running alpine 3.5 where php7 is available but the default is still php5. Previous implementation assumed php7 would be the default for alpine 3.5.

This also improves the usage of different runtimes by creating a symlink for the provided runtime at the default runtime location (`/usr/bin/php`) if it not exists. This is needed because php packages expect the binary `php` to be on PATH. While some OS packages already do this (e.g hhvm on Ubuntu Xenial) some do not (e.g php7 in alpine 3.5)

closes #385