### PR TITLE
WIP: yarn support

### DIFF
--- a/docs/build_steps.rst
+++ b/docs/build_steps.rst
@@ -1122,6 +1122,34 @@ Node.JS Commands
         Setting the option to ``false`` is useful for setting up custom
         version of the node.js.
 
+.. step:: YarnDependencies
+
+   Works similarly to :step:`NpmDependencies` but installs packages using yarn
+   aand For example::
+
+        - !YarnDependencies
+
+   This installs dependencies and ``devDependencies`` from ``package.json``
+   into a container's ``/usr/lib/node_modules``.
+
+   The settings in :step:`NpmConfig` to affect this command.
+
+   Options:
+
+   production
+       (default ``false``) If set to ``true`` does not install
+       ``devDependencies`` (corresponds to ``--production`` flag for yarn)
+   optional
+       (default ``false``) If set to ``true`` install optional dependencies
+
+   dir
+       (default ``.``) Base directory where ``package.json`` is. Note: unlike
+       in :setup:`NpmDependencies` we don't specify the path to the file,
+       but to the directory because we track both ``package.json`` and
+       ``yarn.lock`` files in there.
+
+.. _yarn: https://yarnpkg.com/
+
 
 Python Commands
 ===============

--- a/src/builder/commands/alpine.rs
+++ b/src/builder/commands/alpine.rs
@@ -255,6 +255,7 @@ impl Distro {
             packages::NodeJs => Some(vec!()),
             packages::NodeJsDev => Some(vec!("nodejs-dev")),
             packages::Npm => Some(vec!()),
+            packages::Yarn => None,
             // PHP
             packages::Php => Some(vec!()),
             packages::PhpDev => Some(self.php_build_deps()),
@@ -284,6 +285,7 @@ impl Distro {
             packages::NodeJs => Some(vec!("nodejs")),
             packages::NodeJsDev => Some(vec!()),
             packages::Npm => Some(vec!("nodejs")),  // Need duplicate?
+            packages::Yarn => None,
             // PHP
             packages::Php => Some(self.php_system_deps()),
             packages::PhpDev => Some(vec!()),

--- a/src/builder/commands/npm.rs
+++ b/src/builder/commands/npm.rs
@@ -82,7 +82,6 @@ impl Default for NpmConfig {
 pub struct YarnDependencies {
     pub dir: PathBuf,
     pub production: bool,
-    pub flat: bool,
     pub optional: bool,
 }
 
@@ -92,7 +91,6 @@ impl YarnDependencies {
         .member("dir", V::Directory::new().absolute(false).default("."))
         .member("production", V::Scalar::new().default(false))
         .member("optional", V::Scalar::new().default(false))
-        .member("flat", V::Scalar::new().default(false))
     }
 }
 
@@ -397,7 +395,6 @@ impl BuildStep for YarnDependencies {
         -> Result<(), VersionError>
     {
         hash.field("production", self.production);
-        hash.field("flat", self.flat);
         let lock_file = Path::new("/work").join(&self.dir).join("yarn.lock");
         let package = Path::new("/work").join(&self.dir).join("package.json");
         if lock_file.exists() {
@@ -453,9 +450,6 @@ impl BuildStep for YarnDependencies {
             // cmd.arg("--frozen-lockfile");
             if self.production {
                 cmd.arg("--production");
-            }
-            if self.flat {
-                cmd.arg("--flat");
             }
             run(cmd)?;
             // TODO(tailhook) find some heuristics to determine that lockfile

--- a/src/builder/commands/npm.rs
+++ b/src/builder/commands/npm.rs
@@ -1,14 +1,18 @@
 use std::fs::File;
 use std::path::{Path, PathBuf};
+use std::os::unix::fs::{symlink};
 
 use quire::validate as V;
+use quick_error::ResultExt;
 use unshare::{Stdio};
 use rustc_serialize::json::Json;
 
+use capsule::download::download_file;
 use super::super::context::{Context};
 use super::super::packages;
 use builder::distrib::{Distribution, DistroBox};
 use builder::commands::generic::{command, run};
+use builder::commands::tarcmd::unpack_subdir;
 use build_step::{BuildStep, VersionError, StepError, Digest, Config, Guard};
 
 
@@ -67,6 +71,20 @@ impl Default for NpmConfig {
     }
 }
 
+#[derive(RustcDecodable, Debug)]
+pub struct YarnDependencies {
+    pub dir: PathBuf,
+    pub production: bool,
+}
+
+impl YarnDependencies {
+    pub fn config() -> V::Structure<'static> {
+        V::Structure::new()
+        .member("dir", V::Directory::new().absolute(false).default("."))
+        .member("production", V::Scalar::new().default(false))
+    }
+}
+
 fn scan_features(settings: &NpmConfig, pkgs: &Vec<String>)
     -> Vec<packages::Package>
 {
@@ -91,13 +109,6 @@ pub fn parse_feature(info: &str, features: &mut Vec<packages::Package>) {
     } // TODO(tailhook) implement whole a lot of other npm version kinds
 }
 
-pub fn ensure_npm(distro: &mut Box<Distribution>, ctx: &mut Context,
-    features: &[packages::Package])
-    -> Result<(), StepError>
-{
-    packages::ensure_packages(distro, ctx, features)
-}
-
 pub fn npm_install(distro: &mut Box<Distribution>, ctx: &mut Context,
     pkgs: &Vec<String>)
     -> Result<(), StepError>
@@ -105,7 +116,7 @@ pub fn npm_install(distro: &mut Box<Distribution>, ctx: &mut Context,
     ctx.add_cache_dir(Path::new("/tmp/npm-cache"),
                            "npm-cache".to_string())?;
     let features = scan_features(&ctx.npm_settings, pkgs);
-    ensure_npm(distro, ctx, &features)?;
+    packages::ensure_packages(distro, ctx, &features)?;
 
     if pkgs.len() == 0 {
         return Ok(());
@@ -183,7 +194,7 @@ pub fn npm_deps(distro: &mut Box<Distribution>, ctx: &mut Context,
             &mut packages, &mut features)?;
     }
 
-    ensure_npm(distro, ctx, &features)?;
+    packages::ensure_packages(distro, ctx, &features)?;
 
     if packages.len() == 0 {
         return Ok(());
@@ -295,6 +306,84 @@ impl BuildStep for NpmDependencies {
         guard.distro.npm_configure(&mut guard.ctx)?;
         if build {
             npm_deps(&mut guard.distro, &mut guard.ctx, &self)?;
+        }
+        Ok(())
+    }
+    fn is_dependent_on(&self) -> Option<&str> {
+        None
+    }
+}
+
+fn yarn_scan_features(settings: &NpmConfig, pkgs: &Vec<String>)
+    -> Vec<packages::Package>
+{
+    let mut res = vec!();
+    res.push(packages::BuildEssential);
+    if settings.install_node {
+        res.push(packages::NodeJs);
+        res.push(packages::NodeJsDev);
+        res.push(packages::Yarn);
+    }
+    for name in pkgs.iter() {
+        parse_feature(&name, &mut res);
+    }
+    return res;
+}
+
+pub fn setup_yarn(ctx: &mut Context)
+    -> Result<(), String>
+{
+    let filename = download_file(&mut ctx.capsule,
+        &["https://yarnpkg.com/latest.tar.gz"], None)?;
+    unpack_subdir(ctx, &filename,
+        &Path::new("/vagga/root/usr/lib/yarn"), Path::new("dist"))?;
+    symlink("/usr/lib/yarn/bin/yarn", "/vagga/root/usr/bin/yarn")
+        .map_err(|e| format!("Can't create yarn symlink: {}", e))?;
+    Ok(())
+}
+
+impl BuildStep for YarnDependencies {
+    fn name(&self) -> &'static str { "YarnDependencies" }
+    fn hash(&self, _cfg: &Config, hash: &mut Digest)
+        -> Result<(), VersionError>
+    {
+        hash.field("production", self.production);
+        let lock_file = Path::new("/work").join(&self.dir).join("yarn.lock");
+        if lock_file.exists() {
+            let mut file = File::open(&lock_file).context(&lock_file)?;
+            hash.file(&lock_file, &mut file).context(&lock_file)?;
+            Ok(())
+        } else {
+            Err(VersionError::New)
+        }
+    }
+    fn build(&self, guard: &mut Guard, build: bool)
+        -> Result<(), StepError>
+    {
+        if build {
+            let base_dir = Path::new("/work").join(&self.dir);
+            let lock_file = base_dir.join("yarn.lock");
+
+            guard.ctx.add_cache_dir(Path::new("/tmp/yarn-cache"),
+                                    "yarn-cache".to_string())?;
+            let features = yarn_scan_features(
+                &guard.ctx.npm_settings, &Vec::new());
+            packages::ensure_packages(
+                &mut guard.distro, &mut guard.ctx, &features)?;
+            let mut cmd = command(&guard.ctx, "/usr/bin/yarn")?;
+            cmd.current_dir(&base_dir);
+            cmd.arg("install");
+            cmd.arg("--modules-folder=/usr/lib/node_modules");
+            cmd.arg("--cache-folder=/tmp/yarn-cache");
+            if lock_file.exists() {
+                cmd.arg("--frozen-lockfile");
+            }
+            if self.production {
+                cmd.arg("--production");
+            }
+            run(cmd)?;
+            // TODO(tailhook) find some heuristics to determine that lockfile
+            // needs to be updated to print some message
         }
         Ok(())
     }

--- a/src/builder/commands/npm.rs
+++ b/src/builder/commands/npm.rs
@@ -75,6 +75,7 @@ impl Default for NpmConfig {
 pub struct YarnDependencies {
     pub dir: PathBuf,
     pub production: bool,
+    pub flat: bool,
 }
 
 impl YarnDependencies {
@@ -82,6 +83,7 @@ impl YarnDependencies {
         V::Structure::new()
         .member("dir", V::Directory::new().absolute(false).default("."))
         .member("production", V::Scalar::new().default(false))
+        .member("flat", V::Scalar::new().default(false))
     }
 }
 
@@ -348,6 +350,7 @@ impl BuildStep for YarnDependencies {
         -> Result<(), VersionError>
     {
         hash.field("production", self.production);
+        hash.field("flat", self.flat);
         let lock_file = Path::new("/work").join(&self.dir).join("yarn.lock");
         if lock_file.exists() {
             let mut file = File::open(&lock_file).context(&lock_file)?;
@@ -380,6 +383,9 @@ impl BuildStep for YarnDependencies {
             }
             if self.production {
                 cmd.arg("--production");
+            }
+            if self.flat {
+                cmd.arg("--flat");
             }
             run(cmd)?;
             // TODO(tailhook) find some heuristics to determine that lockfile

--- a/src/builder/commands/ubuntu.rs
+++ b/src/builder/commands/ubuntu.rs
@@ -463,6 +463,7 @@ impl Distro {
             packages::NodeJs => Some(vec!("nodejs")),
             packages::NodeJsDev => Some(vec!()),
             packages::Npm => Some(vec!()),
+            packages::Yarn => None,
             // PHP
             packages::Php if self.has_php7() => {
                 // In ubuntu xenial, php package does not bundles the json and zip modules required
@@ -503,6 +504,7 @@ impl Distro {
             packages::NodeJs => Some(vec!()),
             packages::NodeJsDev => Some(vec!("nodejs-dev")),
             packages::Npm => Some(vec!("npm")),
+            packages::Yarn => None,
             // PHP
             packages::Php => Some(vec!()),
             packages::PhpDev if self.has_php7() => Some(vec!("php-dev")),

--- a/src/builder/packages.rs
+++ b/src/builder/packages.rs
@@ -1,12 +1,13 @@
 use std::path::Path;
 
-use super::context::Context;
-use super::commands::generic::run_command_at_env;
-use super::commands::gem;
-use capsule::download;
-use builder::error::StepError;
-use builder::distrib::Distribution;
 use builder::commands::composer;
+use builder::commands::gem;
+use builder::commands::generic::run_command_at_env;
+use builder::commands::npm;
+use builder::context::Context;
+use builder::distrib::Distribution;
+use builder::error::StepError;
+use capsule::download;
 use file_util::copy;
 
 pub use self::Package::*;
@@ -31,6 +32,7 @@ pub enum Package {
     NodeJs,     // not build dep
     NodeJsDev,
     Npm,
+    Yarn,
 
     Php,        // not build dep
     PhpDev,
@@ -64,6 +66,7 @@ fn generic_packages(ctx: &mut Context, features: Vec<Package>)
             }
             Composer => composer::bootstrap(ctx)?,
             Bundler => gem::setup_bundler(ctx)?,
+            Yarn => npm::setup_yarn(ctx)?,
             _ => {
                 left.push(i);
                 continue;

--- a/src/config/builders.rs
+++ b/src/config/builders.rs
@@ -47,6 +47,7 @@ const COMMANDS: &'static [&'static str] = &[
     "SubConfig",
     "NpmConfig",
     "NpmDependencies",
+    "YarnDependencies",
     "NpmInstall",
     "GemInstall",
     "GemBundle",
@@ -124,6 +125,7 @@ pub fn builder_validator<'x>() -> V::Enum<'x> {
     .option("NpmConfig", cmd::npm::NpmConfig::config())
     .option("NpmInstall", cmd::npm::NpmInstall::config())
     .option("NpmDependencies", cmd::npm::NpmDependencies::config())
+    .option("YarnDependencies", cmd::npm::YarnDependencies::config())
 
     // Composer
     .option("ComposerConfig", cmd::composer::ComposerConfig::config())
@@ -185,6 +187,7 @@ fn decode_step<D: Decoder>(options: &[&str], index: usize, d: &mut D)
         "SubConfig" => step(cmd::subcontainer::SubConfig::decode(d)),
         "NpmConfig" => step(cmd::npm::NpmConfig::decode(d)),
         "NpmDependencies" => step(cmd::npm::NpmDependencies::decode(d)),
+        "YarnDependencies" => step(cmd::npm::YarnDependencies::decode(d)),
         "NpmInstall" => step(cmd::npm::NpmInstall::decode(d)),
         "GemInstall" => step(cmd::gem::GemInstall::decode(d)),
         "GemBundle" => step(cmd::gem::GemBundle::decode(d)),

--- a/src/version/error.rs
+++ b/src/version/error.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use regex;
 use rustc_serialize::json;
@@ -35,6 +35,8 @@ quick_error! {
             cause(err)
             description("io error")
             display("Error reading {:?}: {}", path, err)
+            context(p: &'a Path, err: io::Error) -> (err, p.to_path_buf())
+            context(p: &'a PathBuf, err: io::Error) -> (err, p.to_path_buf())
         }
         /// Container needed for build is not found
         ContainerNotFound(name: String) {

--- a/src/version/error.rs
+++ b/src/version/error.rs
@@ -51,6 +51,8 @@ quick_error! {
         Json(err: json::BuilderError, path: PathBuf) {
             description("can't read json")
             display("error reading json {:?}: {:?}", path, err)
+            context(p: &'a PathBuf, err: json::BuilderError)
+                -> (err, p.to_path_buf())
         }
     }
 }

--- a/tests/yarn.bats
+++ b/tests/yarn.bats
@@ -1,0 +1,42 @@
+setup() {
+    cd /work/tests/yarn
+    rm yarn.lock || true
+}
+
+@test "yarn: " {
+    cat <<END > package.json
+{
+  "devDependencies": {
+    "resolve-cli": "0.1"
+  }
+}
+END
+    run vagga resolve .
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ ${lines[${#lines[@]}-1]} = /work ]]
+    link=$(readlink .vagga/pkg)
+    [[ $link = ".roots/pkg.77bfb14b/root" ]]
+
+    run vagga stat /usr/lib/node_modules/classnames
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 1 ]]
+
+    cat <<END > package.json
+
+{
+  "dependencies": {
+    "classnames": "2.2"
+  },
+  "devDependencies": {
+    "resolve-cli": "0.1"
+  }
+}
+END
+    run vagga stat /usr/lib/node_modules/classnames
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    [[ ${lines[${#lines[@]}-7]} = "  File: /usr/lib/node_modules/classnames" ]]
+    link=$(readlink .vagga/pkg)
+    [[ $link = ".roots/pkg.ec1b39f0/root" ]]
+}

--- a/tests/yarn.bats
+++ b/tests/yarn.bats
@@ -16,7 +16,7 @@ END
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = /work ]]
     link=$(readlink .vagga/pkg)
-    [[ $link = ".roots/pkg.77bfb14b/root" ]]
+    [[ $link = ".roots/pkg.06f039be/root" ]]
 
     run vagga stat /usr/lib/node_modules/classnames
     printf "%s\n" "${lines[@]}"
@@ -38,5 +38,5 @@ END
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-7]} = "  File: /usr/lib/node_modules/classnames" ]]
     link=$(readlink .vagga/pkg)
-    [[ $link = ".roots/pkg.ec1b39f0/root" ]]
+    [[ $link = ".roots/pkg.1a63a916/root" ]]
 }

--- a/tests/yarn/.gitignore
+++ b/tests/yarn/.gitignore
@@ -1,0 +1,2 @@
+/package.json
+/yarn.lock

--- a/tests/yarn/vagga.yaml
+++ b/tests/yarn/vagga.yaml
@@ -1,0 +1,20 @@
+containers:
+
+  pkg:
+    setup:
+    - !Alpine v3.5
+    - !YarnDependencies
+
+
+commands:
+  resolve: !Command
+    container: pkg
+    run: [resolve]
+    environ:
+      PATH: "/usr/lib/node_modules/.bin:\
+        /usr/local/sbin:/usr/local/bin:\
+        /usr/sbin:/usr/bin:/sbin:/bin"
+
+  stat: !Command
+    container: pkg
+    run: [stat]

--- a/vagga.yaml
+++ b/vagga.yaml
@@ -88,6 +88,9 @@ commands:
   cargo: !Command
     description: Run arbitrary cargo command
     container: rust-musl
+    environ:
+      VAGGA_VERSION: v0.0.0-test
+      RUST_BACKTRACE: 1
     run: [cargo]
 
   test-internal: !Command


### PR DESCRIPTION
* [x] docs
* [ ] when `node_modules` are present in directory, yarn uses it instead of `--modules-folder` (warn?/create a signature file?)
* [ ] rename `YarnDependencies` -> `Yarn` (?)
* [ ] `YarnInstall` which does `yarn global add` (?)
* [x] tests
* [x] `flat: true` (?)
* [x] need to build container twice when there are no lockfile (was old vagga bug)
* [x] we don't depend on `package.json` but depend on `yarn.lock` which isn't too good (since we already have an update mechanism for lock, we are probably going to hash both files to be more strict with removing dependency back)
* [ ] how to do `yarn add`? Docs are enough?
* [x] install optional dependencies, add the option