### PR TITLE
Fixed config location for some internal commands

### DIFF
--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -1,9 +1,9 @@
-use std::io::{stdout, stderr, Write};
+use std::io::{stdout, stderr};
 use std::default::Default;
 use std::path::Path;
 use rand;
 
-use config::find_config;
+use config::find_config_or_exit;
 use config::{Config, Container, Settings};
 use argparse::{ArgumentParser, Store, StoreTrue};
 
@@ -71,14 +71,7 @@ pub fn run(input_args: Vec<String>) -> i32 {
         }
     }
 
-    let config = match find_config(&Path::new("/work"), false) {
-        Ok((cfg, _)) => cfg,
-        Err(e) => {
-            writeln!(&mut stderr(), "Error parsing configuration file: {}", e)
-                .ok();
-            return 126;
-        }
-    };
+    let (config, _) = find_config_or_exit(&Path::new("/work"), false);
     let container = config.containers.get(&container_name)
         .expect(&format!("Container {:?} not found", &container_name));
 

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -47,10 +47,10 @@ pub fn config_validator<'a>() -> V::Structure<'a> {
         command_validator()))
 }
 
-fn find_config_path(work_dir: &PathBuf, show_warnings: bool)
+fn find_config_path(work_dir: &Path, show_warnings: bool)
     -> Option<(PathBuf, PathBuf)>
 {
-    let mut dir = work_dir.clone();
+    let mut dir = work_dir.to_path_buf();
     loop {
         if show_warnings {
             maybe_print_typo_warning(&dir.join(".vagga"));
@@ -72,7 +72,7 @@ fn find_config_path(work_dir: &PathBuf, show_warnings: bool)
     }
 }
 
-pub fn find_config(work_dir: &PathBuf, show_warnings: bool)
+pub fn find_config(work_dir: &Path, show_warnings: bool)
     -> Result<(Config, PathBuf), String>
 {
     let (cfg_dir, filename) = match find_config_path(

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -1,8 +1,9 @@
 use std::fs::File;
-use std::io::{Read};
+use std::io::{stderr, Read, Write};
 use std::mem;
 use std::path::{PathBuf, Path, Component};
 use std::rc::Rc;
+use std::process::exit;
 
 use std::collections::BTreeMap;
 
@@ -47,12 +48,12 @@ pub fn config_validator<'a>() -> V::Structure<'a> {
         command_validator()))
 }
 
-fn find_config_path(work_dir: &Path, show_warnings: bool)
+fn find_config_path(work_dir: &Path, verbose: bool)
     -> Option<(PathBuf, PathBuf)>
 {
     let mut dir = work_dir.to_path_buf();
     loop {
-        if show_warnings {
+        if verbose {
             maybe_print_typo_warning(&dir.join(".vagga"));
             maybe_print_typo_warning(&dir);
         }
@@ -72,23 +73,37 @@ fn find_config_path(work_dir: &Path, show_warnings: bool)
     }
 }
 
-pub fn find_config(work_dir: &Path, show_warnings: bool)
+pub fn find_config(work_dir: &Path, verbose: bool)
     -> Result<(Config, PathBuf), String>
 {
-    let (cfg_dir, filename) = match find_config_path(
-        work_dir, show_warnings)
-    {
+    let (cfg_dir, filename) = match find_config_path(work_dir, verbose) {
         Some(pair) => pair,
         None => return Err(format!(
             "Config not found in path {:?}", work_dir)),
     };
     assert!(cfg_dir.is_absolute());
-    if show_warnings {
+    if verbose {
         info!("Found configuration file: {:?}", &filename);
     }
     let cfg = read_config(&filename)?;
     validate_config(&cfg)?;
     return Ok((cfg, cfg_dir));
+}
+
+pub fn find_config_or_exit(work_dir: &Path, verbose: bool)
+    -> (Config, PathBuf)
+{
+    match find_config(work_dir, verbose) {
+        Ok(pair) => pair,
+        Err(e) => {
+            writeln!(&mut stderr(),
+                "Error parsing configuration file: {}. \
+                 It usually happens either if configuration file was changed \
+                 after vagga have been started or if permissions of the config \
+                 file or some of the included files are wrong.", e).ok();
+            exit(126);
+        }
+    }
 }
 
 fn join_path<A, B>(base: A, relative: B) -> Result<PathBuf, String>

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -83,6 +83,9 @@ pub fn find_config(work_dir: &Path, show_warnings: bool)
             "Config not found in path {:?}", work_dir)),
     };
     assert!(cfg_dir.is_absolute());
+    if show_warnings {
+        info!("Found configuration file: {:?}", &filename);
+    }
     let cfg = read_config(&filename)?;
     validate_config(&cfg)?;
     return Ok((cfg, cfg_dir));

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,7 +1,7 @@
 pub use self::settings::Settings;
 pub use self::containers::{Container};
 pub use self::range::Range;
-pub use self::config::{Config, read_config, find_config};
+pub use self::config::{Config, read_config, find_config, find_config_or_exit};
 
 pub mod settings;
 pub mod read_settings;

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,10 +1,10 @@
-use std::io::{stdout, stderr, Write};
+use std::io::{stdout, stderr};
 use std::path::Path;
 
 use argparse::{ArgumentParser, Store, List};
 
 use config::Config;
-use super::config::find_config;
+use super::config::find_config_or_exit;
 use self::iptables::apply_graph;
 
 mod graphs;
@@ -50,15 +50,7 @@ pub fn run(cmdline: Vec<String>) -> i32 {
         }
     }
 
-
-    let cfg = match find_config(&Path::new("/work"), false) {
-        Ok((cfg, _)) => cfg,
-        Err(e) => {
-            writeln!(&mut stderr(), "Error parsing configuration file: {}", e)
-                .ok();
-            return 126;
-        }
-    };
+    let (cfg, _) = find_config_or_exit(&Path::new("/work"), false);
 
     args.insert(0, format!("vagga_network {}", kind));
     match run_command(&cfg, kind, args) {

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -6,7 +6,7 @@ use std::os::unix::io::FromRawFd;
 
 use argparse::{ArgumentParser, Store, StoreTrue};
 
-use config::find_config;
+use config::find_config_or_exit;
 use config::Settings;
 
 
@@ -49,14 +49,7 @@ pub fn run(input_args: Vec<String>) -> i32 {
         }
     }
 
-    let cfg = match find_config(&Path::new("/work"), false) {
-        Ok((cfg, _)) => cfg,
-        Err(e) => {
-            writeln!(&mut stderr(), "Error parsing configuration file: {}", e)
-                .ok();
-            return 126;
-        }
-    };
+    let (cfg, _) = find_config_or_exit(&Path::new("/work"), false);
     let cont = cfg.containers.get(&container)
         .expect(&format!("Container {:?} not found", &container));
 

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -6,7 +6,7 @@ use std::os::unix::io::FromRawFd;
 
 use argparse::{ArgumentParser, Store, StoreTrue};
 
-use config::read_config;
+use config::find_config;
 use config::Settings;
 
 
@@ -49,11 +49,16 @@ pub fn run(input_args: Vec<String>) -> i32 {
         }
     }
 
-    // TODO(tailhook) read also config from /work/.vagga/vagga.yaml
-    let cfg = read_config(&Path::new("/work/vagga.yaml")).ok()
-        .expect("Error parsing configuration file");  // TODO
+    let cfg = match find_config(&Path::new("/work"), false) {
+        Ok((cfg, _)) => cfg,
+        Err(e) => {
+            writeln!(&mut stderr(), "Error parsing configuration file: {}", e)
+                .ok();
+            return 126;
+        }
+    };
     let cont = cfg.containers.get(&container)
-        .expect("Container not found");  // TODO
+        .expect(&format!("Container {:?} not found", &container));
 
     let hash = match version::long_version(&cont, &cfg, debug_info, dump) {
         Ok(hash) => hash,

--- a/src/wrapper/mod.rs
+++ b/src/wrapper/mod.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use argparse::{ArgumentParser, Store, StoreOption, List};
 
-use super::config::{find_config, Config, Settings};
+use super::config::{find_config_or_exit, Config, Settings};
 use super::config::command::MainCommand::{Command, Supervise, CapsuleCommand};
 use config::read_settings::{read_settings, MergedSettings};
 
@@ -67,13 +67,7 @@ pub fn run(input_args: Vec<String>) -> i32 {
 
     let workdir = current_dir().unwrap();
 
-    let (config, project_root) = match find_config(&workdir, false) {
-        Ok(tup) => tup,
-        Err(e) => {
-            writeln!(&mut err, "{}", e).ok();
-            return 126;
-        }
-    };
+    let (config, project_root) = find_config_or_exit(&workdir, false);
     let (ext_settings, int_settings) = match read_settings(&project_root)
     {
         Ok(tup) => tup,


### PR DESCRIPTION
Possibly we should print warning when `.vagga/vagga.yaml` is used. Or print info message what config file was found.