### PR TITLE
Fix downloading yarn version from GitHub.

### DIFF
--- a/src/builder/commands/npm.rs
+++ b/src/builder/commands/npm.rs
@@ -394,7 +394,7 @@ pub fn setup_yarn(ctx: &mut Context)
     let link = match ctx.npm_settings.yarn_version {
         Some(ref ver) => {
             format!("https://github.com/yarnpkg/yarn/\
-                     releases/download/{0}/yarn-{0}.tar.gz", ver)
+                     releases/download/v{0}/yarn-v{0}.tar.gz", ver)
         }
         None => String::from("https://yarnpkg.com/latest.tar.gz"),
     };


### PR DESCRIPTION
`vagga` attempt to download yarn by `yarn-version` leads to,

```
ERROR:vagga::capsule::download: Error downloading "https://github.com/yarnpkg/yarn/releases/download/0.27.5/yarn-0.27.5.tar.gz", wget Exited(8)
ERROR:vagga::builder: Error building container "frontend": step YarnDependencies { dir: ".", production: false, optional: true } failed: Error downloading file "/vagga/cache/downloads/c5ee0b78-yarn-0.27.5.tar.gz" from ["https://github.com/yarnpkg/yarn/releases/download/0.27.5/yarn-0.27.5.tar.gz"]
ERROR:vagga::wrapper: Error executing _build: Builder exited with code 1
```

Cause there is no,

```
https://github.com/yarnpkg/yarn/releases/download/0.27.5/yarn-0.27.5.tar.gz
```

as yarn 0.27.5 available at,

```
https://github.com/yarnpkg/yarn/releases/download/v0.27.5/yarn-v0.27.5.tar.gz
```

This one-liner fixed it.

----

BTW, this PR not fixed an issue with installing `latest` Yarn version,

```
ERROR:vagga::capsule::download: Error downloading "https://github.com/yarnpkg/yarn/releases/download/latest/yarn-latest.tar.gz", wget Exited(8)
ERROR:vagga::builder: Error building container "frontend": step YarnDependencies { dir: ".", production: false, optional: true } failed: Error downloading file "/vagga/cache/downloads/cc383185-yarn-latest.tar.gz" from ["https://github.com/yarnpkg/yarn/releases/download/latest/yarn-latest.tar.gz"]
```

I'm not sure that logic behind downloading `latest` yarn version is proper one.