### PR TITLE
Fixed eventual hhvm test error

### DIFF
--- a/src/builder/commands/composer.rs
+++ b/src/builder/commands/composer.rs
@@ -218,6 +218,11 @@ pub fn configure(ctx: &mut Context) -> Result<(), String> {
     ctx.environ.insert("COMPOSER_ALLOW_SUPERUSER".to_owned(),
                        "1".to_owned());
 
+    // Fix date_default_timezone_get function which can return
+    // empty string instead of "UTC". Reproduced on travis-ci
+    // with Ubuntu Xenial and hhvm-3.11.1
+    ctx.environ.entry("TZ".to_string()).or_insert("UTC".to_string());
+
     Ok(())
 }
 


### PR DESCRIPTION
Sometimes hhvm's `date_default_timezone_get` function returns empty string that leads to the following error (despite that the documentation says that it should return `UTC` when it is not possible to determine timezone):
```
# Notice: Timezone ID '' is invalid in phar://composer.phar/bin/../src/../src/Composer/Console/Application.php on line 71
# You are already using composer version 1.4.2 (stable channel).
# Notice: Timezone ID '' is invalid in phar://composer.phar/bin/../src/../src/Composer/Console/Application.php on line 71
# Changed current directory to /usr/local/lib/composer
# ./composer.json has been created
#                                                                                                                                                                                                                                                                                                                                                              
#   [ErrorException]                                                                                                                                                                                                                                                                                                                                           
#   It is not safe to rely on the system's timezone settings. Please use the date.timezone setting, the TZ environment variable or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected 'UTC' for 'UTC/0.0/no DST' instead  
#                                                                                                                                                                                                                                                                                                                                                              
# require [--dev] [--prefer-source] [--prefer-dist] [--no-progress] [--no-suggest] [--no-update] [--no-scripts] [--update-no-dev] [--update-with-dependencies] [--ignore-platform-reqs] [--prefer-stable] [--prefer-lowest] [--sort-packages] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--] [<packages>]...
# ERROR:vagga::builder: Error building container "hhvm-ubuntu-xenial": step ComposerInstall(["laravel/installer:1.3.0"]) failed: error running <Command "/usr/bin/hhvm" "/usr/local/bin/composer" "--no-interaction" "global" "require" "--prefer-dist" "--update-no-dev" "laravel/installer:1.3.0"; environ[10]; chroot="/vagga/root"; work-dir="/work"> exited with code 1
# ERROR:vagga::wrapper: Error executing _build: Builder exited with code 1
# Command <Command "/proc/self/exe" "__wrapper__" "_build" "hhvm-ubuntu-xenial"; environ[4]; uid_map=[UidMap { inside_uid: 0, outside_uid: 0, count: 1 }, UidMap { inside_uid: 1, outside_uid: 1, count: 65535 }]; gid_map=[GidMap { inside_gid: 0, outside_gid: 0, count: 1 }, GidMap { inside_gid: 1, outside_gid: 1, count: 65535 }]> exited with code 124
```

It was interesting investigation. The only thing why that could happen I think is a race condition when initializing static variable `s_guessed_timezone`: https://github.com/facebook/hhvm/blob/HHVM-3.11/hphp/runtime/base/timezone.cpp#L77
Hhvm on Ubuntu Xenial was build against gcc 5.3.1. Default mode for pre-6 gcc is `-std=gnu++98`. But only `C++11` standard garantees thread safe initialization of the static variables.