### PR TITLE
Copy command now set files' modification time to the first second from the unix epoch

### DIFF
--- a/docs/build_steps.rst
+++ b/docs/build_steps.rst
@@ -640,6 +640,8 @@ Generic Commands
    output-file
       (optional) Writes the most recent tag into the file.
 
+   .. versionadded:: 0.7.3
+
 Files and Directories
 =====================
 
@@ -724,6 +726,15 @@ Files and Directories
      (default ``false``)
      Whether to preserve permissions of the copied files. If ``false``
      ``umask`` option is taken into account.
+
+   preserve-times
+     (default ``false``)
+     If ``true`` preserves modification times of the copied files. By default
+     modification times set to the first second from the unix epoch. This
+     behaviour is useful for reproducible builds.
+     Before ``0.7.3`` modification times were set to the current time.
+
+     .. versionadded:: 0.7.3
 
    umask
      (default ``0o002``)

--- a/src/builder/commands/subcontainer.rs
+++ b/src/builder/commands/subcontainer.rs
@@ -8,7 +8,7 @@ use config::read_config;
 use config::containers::Container as Cont;
 use version::short_version;
 use container::util::{copy_dir};
-use file_util::{Dir, shallow_copy};
+use file_util::{Dir, ShallowCopy};
 use build_step::{BuildStep, VersionError, StepError, Digest, Config, Guard};
 
 use builder::error::StepError as E;
@@ -114,10 +114,7 @@ pub fn build(binfo: &Build, guard: &mut Guard, build: bool)
                 try_msg!(copy_dir(&path, &dest, None, None),
                     "Error copying dir {p:?}: {err}", p=path);
             } else {
-                let path_stat = path.symlink_metadata()
-                    .map_err(|e| StepError::Read(path.clone(), e))?;
-                try_msg!(shallow_copy(&path, &path_stat, &dest,
-                        None, None, None),
+                try_msg!(ShallowCopy::new(&path, &dest).copy(),
                     "Error copying file {p:?}: {err}", p=path);
             }
         } else if let Some(ref dest_rel) = binfo.temporary_mount {

--- a/src/container/util.rs
+++ b/src/container/util.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use libc::{uid_t, gid_t};
 
 use super::root::temporary_change_root;
-use file_util::{Dir, shallow_copy};
+use file_util::{Dir, ShallowCopy};
 
 quick_error!{
     #[derive(Debug)]
@@ -101,10 +101,10 @@ pub fn copy_dir(old: &Path, new: &Path,
             oldp.push(&filename);
             newp.push(&filename);
 
-            let oldp_stat = oldp.symlink_metadata()
-                .map_err(|e| Stat(oldp.clone(), e))?;
-            let copy_rc = shallow_copy(&oldp, &oldp_stat, &newp,
-                    owner_uid, owner_gid, None)
+            let copy_rc = ShallowCopy::new(&oldp, &newp)
+                .owner_uid(owner_uid)
+                .owner_gid(owner_gid)
+                .copy()
                 .map_err(|e| CopyFile(oldp.clone(), newp.clone(), e))?;
             if !copy_rc {
                 stack.push(dir);  // Return dir to stack

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -24,6 +24,9 @@ setup() {
     [[ $(stat -c "%a" ".vagga/dir-copy/var/dir/exe.sh") = "775" ]]
     [[ $(stat -c "%a" ".vagga/dir-copy/var/dir/subdir") = "775" ]]
     [[ $(stat -c "%a" ".vagga/dir-copy/var/dir/subdir/file") = "664" ]]
+    # By default we set atime and mtime to 1970-01-01 00:00:01
+    [[ $(stat -c "%X" ".vagga/dir-copy/var/dir/hello") = 1 ]]
+    [[ $(stat -c "%Y" ".vagga/dir-copy/var/dir/hello") = 1 ]]
 }
 
 @test "copy: file" {
@@ -170,4 +173,14 @@ setup() {
     run vagga _version_hash --short depends-glob-rules
     printf "%s\n" "${lines[@]}"
     [[ $output = "375d1004" ]]
+}
+
+@test "copy: preserve times" {
+    run vagga _build copy-preserve-times
+    printf "%s\n" "${lines[@]}"
+    [[ $status = 0 ]]
+    link=$(readlink .vagga/copy-preserve-times)
+    [[ $link = ".roots/copy-preserve-times.6ca4b065/root" ]]
+    [[ $(stat -c '%X %Y' .vagga/copy-preserve-times/dir/hello) = \
+       $(stat -c '%X %Y' dir/hello) ]]
 }

--- a/tests/copy/vagga.yaml
+++ b/tests/copy/vagga.yaml
@@ -90,6 +90,12 @@ containers:
       source: /work/dir
       path: /dir
       preserve-permissions: true
+  copy-preserve-times:
+    setup:
+    - !Copy
+      source: /work/dir
+      path: /dir
+      preserve-times: true
   depends-with-include:
     setup:
     - !Depends


### PR DESCRIPTION
Should we set modification time for subcontainer commands and container snapshots?