### PR TITLE
busybox apk is outdated

### DIFF
--- a/fetch_binaries.sh
+++ b/fetch_binaries.sh
@@ -2,7 +2,7 @@
 ALPINE_VERSION=v3.5
 ALPINE_MIRROR=http://dl-cdn.alpinelinux.org/alpine/
 APK_TOOLS=apk-tools-static-2.6.9-r0.apk
-BUSYBOX=busybox-static-1.25.1-r0.apk
+BUSYBOX=busybox-static-1.25.1-r1.apk
 ALPINE_KEYS=alpine-keys-1.3-r0.apk
 
 
@@ -18,7 +18,7 @@ sha1sum $BUSYBOX
 sha1sum $ALPINE_KEYS
 sha1sum -c - <<SHA1SUMS
 31b29926d6be7efb389b49d9d53b557e9b25eb7c  $APK_TOOLS
-b609218d7b0a1c9ec2e457c7665db8b703c4ef10  $BUSYBOX
+8b5639a22af1e656f03931ab38ef51285b3b9dd2  $BUSYBOX
 f1c6e5f7209885fec5c8dd8c99446036852988a0  $ALPINE_KEYS
 SHA1SUMS
 cd ..


### PR DESCRIPTION
fetch is failing as 'busybox-static-1.25.1-r0.apk' is no longer available under http://dl-cdn.alpinelinux.org/alpine/v3.5/main/x86_64/
