### PR TITLE
use port 80 to connect to ubuntu keyserver

### DIFF
--- a/src/builder/commands/ubuntu.rs
+++ b/src/builder/commands/ubuntu.rs
@@ -383,7 +383,7 @@ impl Distro {
         if let Some(ref srv) = key.server {
             cmd.arg(srv);
         } else {
-            cmd.arg("keyserver.ubuntu.com");
+            cmd.arg("hkp://keyserver.ubuntu.com:80");
         }
         cmd.arg("--recv-keys");
         for item in &key.keys {

--- a/src/builder/commands/ubuntu.rs
+++ b/src/builder/commands/ubuntu.rs
@@ -110,7 +110,7 @@ impl AptTrust {
 }
 
 #[derive(Debug, PartialEq)]
-enum AptHpks {
+enum AptHkps {
     No,
     Installed,
 }
@@ -135,7 +135,7 @@ pub struct Distro {
     codename: Option<String>,
     apt_update: bool,
     apt_https: AptHttps,
-    apt_hpks: AptHpks,
+    apt_hkps: AptHkps,
     has_indices: bool,
     has_universe: bool,
     eatmydata: EatMyData,
@@ -407,14 +407,14 @@ impl Distro {
             }
         };
         if url.starts_with("hkps:") {
-            if AptHpks::Installed != self.apt_hpks {
+            if AptHkps::Installed != self.apt_hkps {
                 if !self.has_universe {
                     debug!("Add Universe for ensure packages");
                     self.enable_universe()?;
                     self.add_universe(ctx)?;
                 }
                 self.install_apt_deps(ctx, &["gnupg-curl", "ca-certificates"])?;
-                self.apt_hpks = AptHpks::Installed;
+                self.apt_hkps = AptHkps::Installed;
             }
         }
         cmd.arg(url);
@@ -797,7 +797,7 @@ pub fn configure(guard: &mut Guard, config: UbuntuRelease)
         codename: None, // unknown yet
         apt_update: true,
         apt_https: AptHttps::No,
-        apt_hpks: AptHpks::No,
+        apt_hkps: AptHkps::No,
         has_indices: false,
         has_universe: false,
     })?;


### PR DESCRIPTION
At office I got an error when I use !AptTrust

According to this info https://gpgtools.tenderapp.com/kb/faq/cant-reach-key-server-are-you-behind-a-company-firewall it's because port 11371 is blocked.

~~~
# this was failing
!AptTrust keys: [93C4A3FD7BB9C367]
# this did working
!Sh
apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 93C4A3FD7BB9C367
~~~

As port 80 should usually not be blocked, I changed default keyserver port in this PR.
Did not yet test this change in office, but expect it to work.

Let me know if you prefer port 443