### PR TITLE
prevents truncation of long symbolic links when unpacking

### DIFF
--- a/src/builder/commands/tarcmd.rs
+++ b/src/builder/commands/tarcmd.rs
@@ -133,7 +133,7 @@ fn unpack_stream<F: Read>(file: F, srcpath: &Path, tgt: &Path,
             }
             dir_builder.create().map_err(&write_err)?;
         } else if entry.is_symlink() {
-            let src = src.header().link_name().map_err(&read_err)?
+            let src = src.link_name().map_err(&read_err)?
                 .ok_or(format!("Error unpacking {:?}, broken symlink", path))?;
             match symlink(&src, &path) {
                 Ok(_) => {},


### PR DESCRIPTION
Unpacking tar archive which contains symbolic links with long names produces broken links as long names get trancuted. This PR fixed issue for me.

Even worse the error get's not detected during unpacking. `symlink(&src, &path)` does not report error even if `src` does not exist.

Don't know if it will be ok to add check if `src` exist at time when symlink get created, because may be targeted `src` file is not yet unpacked. But would be nice to have some inegrity check (checksum ?) of unpacked archive as it leads to strange (and time consuming) errors.