### PR TITLE
Fixed ubuntu xenial

### DIFF
--- a/fetch_binaries.sh
+++ b/fetch_binaries.sh
@@ -1,20 +1,20 @@
 #!/bin/sh -ex
 ALPINE_VERSION=v3.8
 ALPINE_MIRROR=http://dl-cdn.alpinelinux.org/alpine/
-APK_TOOLS=apk-tools-static-2.10.0-r0.apk
-BUSYBOX=busybox-static-1.28.4-r0.apk
+APK_TOOLS=apk-tools-static-2.10.1-r0.apk
+BUSYBOX=busybox-static-1.28.4-r1.apk
 ALPINE_KEYS=alpine-keys-2.1-r1.apk
 
 ARCH=${1:-x86_64}
 
 SHA1SUMS_x86_64="\
-309a288e7730bd1e00f06fb54a8da90f35286a9e  $APK_TOOLS
-09a1b792741e902a817fb9512b65692230323cc0  $BUSYBOX
+6a669b68be304249d5d3398b8db2cc5cc23674bf  $APK_TOOLS
+e14d923f6e24f7a47bb0d8bd1cd8d0d6868d8ae8  $BUSYBOX
 4dd03fa0dfeefdd81ac13d77e0d3ed069821de33  $ALPINE_KEYS"
 
 SHA1SUMS_armhf="\
-9a19667aebd4b404c6be547c451e6c1bdd693953  $APK_TOOLS
-0bc1f7bcc242ea15c4b1fcbd6faeb9b52b5046de  $BUSYBOX
+b30f18f5743d13f1845577e98e629a93c49212a4  $APK_TOOLS
+26a281d4c940e00eba6c9d0772acb1fb56731c32  $BUSYBOX
 a10caf9d8162d5ca16fc77729cfebf9c79d8c87b  $ALPINE_KEYS"
 
 FETCH_DIR="alpine/"$ARCH

--- a/src/container/mount.rs
+++ b/src/container/mount.rs
@@ -8,7 +8,6 @@ use std::ptr::null;
 use libc::{c_ulong, c_int};
 use libmount::{BindMount, Tmpfs};
 
-use file_util::Dir;
 use path_util::ToCString;
 
 // sys/mount.h
@@ -185,7 +184,5 @@ pub fn mount_run(run_dir: &Path) -> Result<(), String> {
         .size_bytes(100 << 20)
         .mode(0o755)
         .mount().map_err(|e| format!("{}", e))?;
-    try_msg!(Dir::new(&run_dir.join("shm")).mode(0o1777).create(),
-        "Error creating /vagga/root/run/shm: {err}");
     Ok(())
 }

--- a/vagga.yaml
+++ b/vagga.yaml
@@ -15,7 +15,7 @@ containers:
       PATH: /musl/bin:/usr/local/bin:/usr/bin:/bin
       HOME: /work/target
     setup:
-    - !Ubuntu xenial
+    - !Ubuntu bionic
     - !UbuntuUniverse
     - !Install [build-essential, ca-certificates, cmake, zlib1g-dev]
     - !Install [file]  # dependency of checkinstall (bug #46)
@@ -44,11 +44,11 @@ containers:
     environ:
       HOME: /work/target
     setup:
-    - !Ubuntu xenial
+    - !Ubuntu bionic
     - !UbuntuUniverse
     - !Text
       /etc/apt/sources.list.d/arm.list: |
-        deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports xenial universe
+        deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports bionic universe
     - !Install
       - build-essential
       - git
@@ -69,7 +69,7 @@ containers:
 
   testbase:
     setup:
-    - !Ubuntu xenial
+    - !Ubuntu bionic
     - !UbuntuUniverse
     - !BuildDeps [wget]
     - !Install [make, curl, zip, file, git]


### PR DESCRIPTION
Canonical updated image for ubuntu xenial. They added `/run/shm` link to the image. This leads to an error:

```
ERROR 2018-10-30T11:26:29Z: vagga::builder: Error building container "rust-musl": step Ubuntu("xenial") failed: Error writing "/vagga/root/run/shm": File exists (os error 17)
ERROR 2018-10-30T11:26:29Z: vagga::wrapper: Error executing _build: Builder exited with code 1
Command <Command "/proc/self/exe" "__wrapper__" "_build" "rust-musl" "--force"; environ[3]; uid_map=[UidMap { inside_uid: 0, outside_uid: 1000, count: 1 }, UidMap { inside_uid: 1, outside_uid: 100000, count: 65535 }]; gid_map=[GidMap { inside_gid: 0, outside_gid: 100, count: 1 }, GidMap { inside_gid: 1, outside_gid: 100000, count: 65535 }]> exited with code 124
```

The error caused by next PR: https://github.com/tailhook/vagga/pull/377