### PR TITLE
Fix alpine tests; update alpine to 3.15

### DIFF
--- a/fetch_binaries.sh
+++ b/fetch_binaries.sh
@@ -1,21 +1,21 @@
 #!/bin/sh -ex
-ALPINE_VERSION=v3.14
+ALPINE_VERSION=v3.15
 ALPINE_MIRROR=http://dl-cdn.alpinelinux.org/alpine/
-APK_TOOLS=apk-tools-static-2.12.7-r0.apk
-BUSYBOX=busybox-static-1.33.1-r3.apk
-ALPINE_KEYS=alpine-keys-2.3-r1.apk
+APK_TOOLS=apk-tools-static-2.12.7-r3.apk
+BUSYBOX=busybox-static-1.34.1-r3.apk
+ALPINE_KEYS=alpine-keys-2.4-r1.apk
 
 ARCH=${1:-x86_64}
 
 SHA1SUMS_x86_64="\
-8799d473cab14110bc76ddcb40117a2aa1af0f52  $APK_TOOLS
-a0b8d2ca9da5d9d0e89c51031ca3df9ee3da2482  $BUSYBOX
-a2ed0478b872f5fdca6dc4c9f5cbcbe5624a2ef2  $ALPINE_KEYS"
+2fa49548020eb850e0a15df03471a07eba55fbc8  $APK_TOOLS
+83a302a36b2239669130d459b14619d066d37f22  $BUSYBOX
+7dba809ae84d5832473f9cbf3bc6522d341299ca  $ALPINE_KEYS"
 
 SHA1SUMS_armhf="\
-98174a1408561462ca6fccfc2b6870e982a6a66d  $APK_TOOLS
-1e14b8eb57cca5ad96a04a5c5a1420606d9b9dd2  $BUSYBOX
-1b9e1fd274ea018749d105c36e854df0ca1dc161  $ALPINE_KEYS"
+49fd9c34731593f5753fbc100dbb344e3f22cf47  $APK_TOOLS
+06bd6d50070251de09f34dd37ebbeb17aa014db8  $BUSYBOX
+1c45ddb6ae0a0aee7793505cce4fcee0d82c7ac1  $ALPINE_KEYS"
 
 FETCH_DIR="alpine/"$ARCH
 mkdir -p "$FETCH_DIR" 2>/dev/null || true

--- a/src/builder/commands/alpine.rs
+++ b/src/builder/commands/alpine.rs
@@ -20,7 +20,7 @@ use config::version::Version;
 use builder::dns::revert_name_files;
 
 
-pub static LATEST_VERSION: &'static str = "v3.14";
+pub static LATEST_VERSION: &'static str = "v3.15";
 static ALPINE_VERSION_REGEX: &'static str = r"^v\d+.\d+$";
 
 const VERSION_WITH_PHP5: &'static str = "v3.4";

--- a/tests/alpine.bats
+++ b/tests/alpine.bats
@@ -3,9 +3,9 @@ setup() {
 }
 
 @test "alpine: Alpine builds" {
-    vagga _build v31
-    link=$(readlink .vagga/v31)
-    [[ $link = ".roots/v31.03b5220b/root" ]]
+    vagga _build v3.15
+    link=$(readlink .vagga/v3.15)
+    [[ $link = ".roots/v3.15.86210ade/root" ]]
 }
 
 @test "alpine: Check stdout" {
@@ -62,22 +62,13 @@ setup() {
     [[ $link = ".roots/v32-calc.a90f78f7/root" ]]
 }
 
-@test "alpine: Run bc on v3.1" {
-    run vagga v31-calc 100*24
-    printf "%s\n" "${lines[@]}"
-    [[ $status -eq 0 ]]
-    [[ ${lines[${#lines[@]}-1]} = "2400" ]]
-    link=$(readlink .vagga/v31-calc)
-    [[ $link = ".roots/v31-calc.effa8865/root" ]]
-}
-
-@test "alpine: Run bc on v3.0" {
-    run vagga v30-calc 23*7+3
+@test "alpine: Run bc on v3.15" {
+    run vagga v3.15-calc 23*7+3
     printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "164" ]]
-    link=$(readlink .vagga/v30-calc)
-    [[ $link = ".roots/v30-calc.6d9ec833/root" ]]
+    link=$(readlink .vagga/v3.15-calc)
+    [[ $link = ".roots/v3.15-calc.9826f0b8/root" ]]
 }
 
 @test "alpine: BuildDeps" {
@@ -203,13 +194,12 @@ setup() {
     printf "%s\n" "${lines[@]}"
     [[ "$output" = "Available commands:
     echo-cmd
+    v3.15-calc
     v37-calc
                         (aliases: new-calc, just-calc)
     vagga-alpine
 
 Old alpine commands:
-    v30-calc
-    v31-calc
     v32-calc
     v33-calc
     v33-tar

--- a/tests/alpine/vagga.yaml
+++ b/tests/alpine/vagga.yaml
@@ -1,5 +1,10 @@
 containers:
 
+  v3.15-calc:
+    setup:
+    - !Alpine v3.15
+    - !Install [bc]
+
   v34-calc:
     setup:
     - !Alpine v3.4
@@ -20,19 +25,9 @@ containers:
     - !Alpine v3.2
     - !Install [bc]
 
-  v31:
+  v3.15:
     setup:
-    - !Alpine v3.1
-
-  v31-calc:
-    setup:
-    - !Alpine v3.1
-    - !Install [bc]
-
-  v30-calc:
-    setup:
-    - !Alpine v3.0
-    - !Install [bc]
+    - !Alpine v3.15
 
   build-deps-with-version:
     setup:
@@ -93,8 +88,22 @@ containers:
 
 commands:
   echo-cmd: !Command
-    container: v31
+    container: v3.15
     run: [echo]
+
+  v3.15-calc: !Command
+    container: v3.15-calc
+    accepts-arguments: true
+    run: echo "$*" | bc
+
+  v37-calc: !Command
+    container: v37-calc
+    aliases:
+    - new-calc
+    - just-calc
+    - echo-cmd  # not really, conflicts with a command
+    accepts-arguments: true
+    run: echo "$*" | bc
 
   v34-calc: !Command
     group: "Old alpine commands"
@@ -114,31 +123,10 @@ commands:
     accepts-arguments: true
     run: echo "$*" | bc
 
-  v31-calc: !Command
-    group: "Old alpine commands"
-    container: v31-calc
-    accepts-arguments: true
-    run: echo "$*" | bc
-
-  v30-calc: !Command
-    group: "Old alpine commands"
-    container: v30-calc
-    accepts-arguments: true
-    run: echo "$*" | bc
-
   v33-tar: !Command
     group: "Old alpine commands"
     container: v33-tar
     run: [tar]
-
-  v37-calc: !Command
-    container: v37-calc
-    aliases:
-    - new-calc
-    - just-calc
-    - echo-cmd  # not really, conflicts with a command
-    accepts-arguments: true
-    run: echo "$*" | bc
 
   vagga-alpine: !Command
     container: vagga-alpine


### PR DESCRIPTION
Alpine 3.1 no longer works:

```
ERROR 2021-12-03T15:35:38Z: vagga::builder: Error building container "v31-calc": step Alpine("v3.1") failed: Error running <Command "/vagga/bin/apk" "--update-cache" "--keys-dir=/etc/apk/keys" "--root=/vagga/root" "--initdb" "add" "alpine-base"; environ[3]>: exited with code 14
ERROR 2021-12-03T15:35:38Z: vagga::wrapper: Error executing _build: Builder exited with code 1
```