### PR TITLE
Fix npm tests; limit minimum supported Alpine version with working npm is 3.9

### DIFF
--- a/src/builder/commands/alpine.rs
+++ b/src/builder/commands/alpine.rs
@@ -305,7 +305,7 @@ impl Distro {
             packages::Npm if version < Version("v3.9") => {
                 // npm fails with segmentation fault on Alpine prior 3.9
                 // See: https://github.com/nodejs/docker-node/issues/813
-                error!("Alpine {} does not support npm", self.version);
+                error!("Vagga does not support npm on Alpine {} (use >= v3.9)", self.version);
                 return Err(StepError::UnsupportedFeatures(vec!(packages::Npm)))
             },
             packages::Npm => Some(vec!("nodejs", "npm")),

--- a/tests/npm.bats
+++ b/tests/npm.bats
@@ -37,7 +37,7 @@ setup() {
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = /work ]]
     link=$(readlink .vagga/pkg-alpine)
-    [[ $link = ".roots/pkg-alpine.8512bd3c/root" ]]
+    [[ $link = ".roots/pkg-alpine.825ac0ab/root" ]]
 }
 
 @test "npm: default git" {
@@ -64,7 +64,7 @@ setup() {
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = /work ]]
     link=$(readlink .vagga/git-alpine)
-    [[ $link = ".roots/git-alpine.0afa9b2c/root" ]]
+    [[ $link = ".roots/git-alpine.0445ebc1/root" ]]
 }
 
 @test "npm: NpmDependencies" {
@@ -73,7 +73,7 @@ setup() {
     [[ $status = 124 ]]  # no resolve but has classnames --v
     [[ -f .vagga/npm-deps/usr/lib/node_modules/classnames/index.js ]]
     link=$(readlink .vagga/npm-deps)
-    [[ $link = ".roots/npm-deps.a3931866/root" ]]
+    [[ $link = ".roots/npm-deps.f9fadad7/root" ]]
 }
 @test "npm: NpmDependencies dev" {
     run vagga _run npm-dev-deps resolve .
@@ -81,14 +81,12 @@ setup() {
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = /work ]]
     link=$(readlink .vagga/npm-dev-deps)
-    [[ $link = ".roots/npm-dev-deps.55eea905/root" ]]
+    [[ $link = ".roots/npm-dev-deps.f4c17a3c/root" ]]
 }
 
-@test "npm: for alpine 3.6" {
+@test "npm: unsupported alpine version" {
     run vagga _run pkg-alpine-36 resolve .
     printf "%s\n" "${lines[@]}"
-    [[ $status = 0 ]]
-    [[ ${lines[${#lines[@]}-1]} = /work ]]
-    link=$(readlink .vagga/pkg-alpine-36)
-    [[ $link = ".roots/pkg-alpine-36.f51dedd3/root" ]]
+    [[ $status = 121 ]]
+    [[ $output = *"Alpine v3.6 does not support npm"* ]]
 }

--- a/tests/npm/vagga.yaml
+++ b/tests/npm/vagga.yaml
@@ -16,7 +16,7 @@ containers:
 
   pkg-alpine:
     setup:
-    - !Alpine v3.4
+    - !Alpine v3.9
     - !NpmInstall [resolve-cli]
 
   git:
@@ -30,17 +30,17 @@ containers:
 
   git-alpine:
     setup:
-    - !Alpine v3.4
+    - !Alpine v3.9
     - !NpmInstall ["git://github.com/Witcher42/resolve-cli"]
 
   npm-deps:
     setup:
-    - !Alpine v3.4
+    - !Alpine v3.9
     - !NpmDependencies { dev: false }
 
   npm-dev-deps:
     setup:
-    - !Alpine v3.4
+    - !Alpine v3.9
     - !NpmDependencies
 
   pkg-alpine-36:


### PR DESCRIPTION
Possibly you know a workaround for the fault:

```
0 info it worked if it ends with ok
1 verbose cli [ '/usr/bin/node', '/usr/bin/npm', 'ls', '--global' ]
2 info using npm@3.10.10
3 info using node@v6.10.3
4 verbose stack Error: could not get uid/gid
4 verbose stack [ 'nobody', 0 ]
4 verbose stack
4 verbose stack     at /usr/lib/node_modules/npm/node_modules/uid-number/uid-number.js:37:16
4 verbose stack     at ChildProcess.exithandler (child_process.js:211:5)
4 verbose stack     at emitTwo (events.js:106:13)
4 verbose stack     at ChildProcess.emit (events.js:191:7)
4 verbose stack     at maybeClose (internal/child_process.js:886:16)
4 verbose stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)
5 verbose cwd /work
6 error Linux 5.15.7-arch1-1
7 error argv "/usr/bin/node" "/usr/bin/npm" "ls" "--global"
8 error node v6.10.3
9 error npm  v3.10.10
10 error code Error: Command failed: /usr/bin/node /usr/lib/node_modules/npm/node_modules/uid-number/get-uid-gid.js nobody 0
10 error code [ 'nobody', 0 ]
10 error code
10 error code     at ChildProcess.exithandler (child_process.js:204:12)
10 error code     at emitTwo (events.js:106:13)
10 error code     at ChildProcess.emit (events.js:191:7)
10 error code     at maybeClose (internal/child_process.js:886:16)
10 error code     at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)
10 error code  { Error: Command failed: /usr/bin/node /usr/lib/node_modules/npm/node_modules/uid-number/get-uid-gid.js nobody 0
10 error code [ 'nobody', 0 ]
10 error code
10 error code     at ChildProcess.exithandler (child_process.js:204:12)
10 error code     at emitTwo (events.js:106:13)
10 error code     at ChildProcess.emit (events.js:191:7)
10 error code     at maybeClose (internal/child_process.js:886:16)
10 error code     at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)
10 error code   killed: false,
10 error code   code: null,
10 error code   signal: 'SIGSEGV',
10 error code   cmd: '/usr/bin/node /usr/lib/node_modules/npm/node_modules/uid-number/get-uid-gid.js nobody 0' }
11 error could not get uid/gid
11 error [ 'nobody', 0 ]
12 error If you need help, you may report this error at:
12 error     <https://github.com/npm/npm/issues>
13 verbose exit [ 1, true ]
```

https://github.com/nodejs/docker-node/issues/813