### PR TITLE
Celan up explicit verbosity in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
         vagga \
           -E UBUNTU_MIRROR=http://mirrors.us.kernel.org/ubuntu/ \
           -E ALPINE_MIRROR=http://mirrors.gigenet.com/alpinelinux/ \
-          test tests/$test.bats --tap
+          test tests/$test.bats --tap --verbose-run --trace
       fi
     done
   else

--- a/tests/alpine.bats
+++ b/tests/alpine.bats
@@ -10,7 +10,6 @@ setup() {
 
 @test "alpine: Check stdout" {
     run echo $(vagga v33-tar -cz vagga.yaml | tar -zt)
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/v33-tar)
     [[ $link = ".roots/v33-tar.ba02400b/root" ]]
@@ -19,25 +18,21 @@ setup() {
 
 @test "alpine: Check version" {
     run vagga _build alpine-check-version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 121 ]]
     [[ $output = *"Error checking alpine version"* ]]
 }
 
 @test "alpine: Run echo command" {
     run vagga echo-cmd hello
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = hello ]]
     run vagga echo-cmd world
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = world ]]
 }
 
 @test "alpine: Run bc on v3.4" {
     run vagga v34-calc 100*24
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "2400" ]]
     link=$(readlink .vagga/v34-calc)
@@ -46,7 +41,6 @@ setup() {
 
 @test "alpine: Run bc on v3.3" {
     run vagga v33-calc 100*24
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "2400" ]]
     link=$(readlink .vagga/v33-calc)
@@ -55,7 +49,6 @@ setup() {
 
 @test "alpine: Run bc on v3.2" {
     run vagga v32-calc 100*24
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "2400" ]]
     link=$(readlink .vagga/v32-calc)
@@ -64,7 +57,6 @@ setup() {
 
 @test "alpine: Run bc on v3.15" {
     run vagga v3.15-calc 23*7+3
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "164" ]]
     link=$(readlink .vagga/v3.15-calc)
@@ -73,14 +65,12 @@ setup() {
 
 @test "alpine: BuildDeps" {
     run vagga _build build-deps-with-version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = *"480191"* ]]
     link=$(readlink .vagga/build-deps-with-version)
     [[ $link = ".roots/build-deps-with-version.5d980472/root" ]]
 
     run vagga _run build-deps-with-version bc
-    printf "%s\n" "${lines[@]}"
     [[ $status = 124 ]]
 }
 
@@ -91,7 +81,6 @@ setup() {
     cp ../../alpine-keys.apk vagga_inside_alpine/
 
     run vagga vagga-alpine
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-2]} = 4eaca212 ]]
     [[ ${lines[${#lines[@]}-1]} = 4eaca212aa896f46307828745d58180d103f129545038b554912ee735cce20c9a710d3966bb5f9cabae28c8370effd13bf81e6b4af48d300dd3a2ee0c54bfbd7 ]]
@@ -99,7 +88,6 @@ setup() {
 
 @test "alpine: AlpineRepo minimal" {
     run vagga _build alpine-repo
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/alpine-repo)
     [[ $link = ".roots/alpine-repo.992729b6/root" ]]
 
@@ -109,13 +97,11 @@ setup() {
     [[ ${repositories[0]} = ${repositories[1]} ]]
 
     run vagga _run alpine-repo tini -h
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
 }
 
 @test "alpine: AlpineRepo full" {
     run vagga _build alpine-repo-full
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/alpine-repo-full)
     [[ $link = ".roots/alpine-repo-full.f703c75a/root" ]]
 
@@ -123,13 +109,11 @@ setup() {
         "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" ]]
 
     run vagga _run alpine-repo-full tini -h
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
 }
 
 @test "alpine: Repo simple" {
     run vagga _build repo-simple
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/repo-simple)
     [[ $link = ".roots/repo-simple.9236cd3f/root" ]]
 
@@ -139,13 +123,11 @@ setup() {
     [[ ${repositories[0]} = ${repositories[1]} ]]
 
     run vagga _run repo-simple tini -h
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
 }
 
 @test "alpine: Repo with branch" {
     run vagga _build repo-with-branch
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/repo-with-branch)
     [[ $link = ".roots/repo-with-branch.9d184847/root" ]]
 
@@ -156,32 +138,26 @@ setup() {
     [[ ${repositories[0]} = ${repositories[1]} ]]
 
     run vagga _run repo-with-branch tini -h
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
 }
 
 @test "alpine: Repo subcontainer" {
     run vagga _build repo-subcontainer
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/repo-subcontainer)
     [[ $link = ".roots/repo-subcontainer.64fdb8f2/root" ]]
 
     run vagga _run repo-subcontainer tini -h
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
 }
 
 @test "alpine: Run bc on v3.7" {
     run vagga v37-calc 50*12
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "600" ]]
     run vagga new-calc 51*13
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "663" ]]
     run vagga just-calc 53*14
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "742" ]]
     link=$(readlink .vagga/v37-calc)
@@ -191,7 +167,6 @@ setup() {
 @test "alpine: descriptions" {
     run vagga
     [[ $status -eq 127 ]]
-    printf "%s\n" "${lines[@]}"
     [[ "$output" = "Available commands:
     echo-cmd
     v3.15-calc

--- a/tests/badcmd.bats
+++ b/tests/badcmd.bats
@@ -4,7 +4,6 @@ setup() {
 
 @test "badcmd: Bad command help message" {
     run vagga bad-cmd
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 126 ]]
     [[ ${lines[${#lines[@]}-2]} =~ .*'Validation Error: Field run is expected'.* ]]
     [[ ${lines[${#lines[@]}-1]} =~ .*'Decode error at .commands.bad-cmd: missing field `run`'.* ]]

--- a/tests/capsule.bats
+++ b/tests/capsule.bats
@@ -16,21 +16,18 @@ setup() {
 
 @test "capsule: Vagga in capsule builds container and prints version" {
     run vagga vagga _capsule build --print-version v35-calc
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "v35-calc.d6315e30" ]]
 }
 
 @test "capsule: Vagga in capsule runs command" {
     run vagga vagga _capsule run v35-calc bc < calc.txt
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "2400" ]]
 }
 
 @test "capsule: Vagga can run local capsule script" {
     run vagga vagga _capsule script ./script.sh 33+27
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "60" ]]
 }
@@ -38,7 +35,6 @@ setup() {
 @test "capsule: Vagga can run remote capsule script" {
     scripturl="https://gist.githubusercontent.com/tailhook/0cf8adf45707c05702e5568b8d390ba9/raw/9f13527f7f94c27504b33f83e76da9514939b4c0/gistfile1.txt"
     run vagga vagga _capsule script "$scripturl" 33+27
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "60" ]]
 }
@@ -46,7 +42,6 @@ setup() {
 @test "capsule: Vagga capsule download" {
     scripturl="https://gist.githubusercontent.com/tailhook/0cf8adf45707c05702e5568b8d390ba9/raw/9f13527f7f94c27504b33f83e76da9514939b4c0/gistfile1.txt"
     run vagga vagga _capsule download "$scripturl"
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "/vagga/cache/downloads/698319cf-gistfile1.txt" ]]
 }

--- a/tests/completion.bats
+++ b/tests/completion.bats
@@ -4,138 +4,114 @@ setup() {
 
 @test "completion: global" {
     run vagga _compgen
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "dont_care no yes" ]]
 
     run vagga _compgen --
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "dont_care no yes" ]]
 
     run vagga _compgen -- -
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "-V --version -E --env --environ -e --use-env \
 --ignore-owner-check --no-image-download --no-build \
 --no-version-check --no-net --no-network --isolate-network" ]]
 
     run vagga _compgen -- --
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "--version --env --environ --use-env \
 --ignore-owner-check --no-image-download --no-build \
 --no-version-check --no-net --no-network --isolate-network" ]]
 
     run vagga _compgen -- y
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "yes" ]]
 
     run vagga _compgen yes --
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "" ]]
 
     run vagga _compgen -- d
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "dont_care" ]]
 
     run vagga _compgen --unknown-option --
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "dont_care no yes" ]]
 
     run vagga _compgen -E test=123 --
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "dont_care no yes" ]]
 
     run vagga _compgen --no-build -- -
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "-V --version -E --env --environ -e --use-env \
 --ignore-owner-check --no-image-download --no-version-check \
 --no-net --no-network --isolate-network" ]]
 
     run vagga _compgen -E test=123 -- -
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "-V --version -E --env --environ -e --use-env \
 --ignore-owner-check --no-image-download --no-build \
 --no-version-check --no-net --no-network --isolate-network" ]]
 
     run vagga _compgen -E test=123 -- d
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "dont_care" ]]
 
     run vagga _compgen -- does
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "" ]]
 
     run vagga _compgen -- --e
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "--env --environ" ]]
 }
 
 @test "completion: supervise" {
     run vagga _compgen dont_care --
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "--only --exclude --no-image-download \
 --no-build --no-version-check" ]]
 
     run vagga _compgen --no-version-check -E HOME=/work dont_care --
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "--only --exclude --no-image-download \
 --no-build --no-version-check" ]]
 
     run vagga _compgen dont_care -- --o
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "--only" ]]
 
     run vagga _compgen dont_care --no-build --
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "--only --exclude --no-image-download \
 --no-version-check" ]]
 
     run vagga _compgen dont_care --only --
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "no yes" ]]
 
     run vagga _compgen dont_care --no-version-check --only --
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "no yes" ]]
 
     run vagga _compgen dont_care --only yes --
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "no" ]]
 
     run vagga _compgen dont_care --only yes -- -
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "--exclude --no-image-download --no-build \
 --no-version-check" ]]
 
     run vagga _compgen dont_care --only yes --no-version-check -- -
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "--exclude --no-image-download --no-build" ]]
 }
 
 @test "completion: builtin" {
     run vagga _compgen -- _
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "_build _build_shell _clean _create_netns \
 _destroy_netns _init_storage_dir _list _pack_image _push_image _run \
@@ -143,74 +119,60 @@ _run_in_netns _version_hash _check_overlayfs_support \
 _base_dir _relative_work_dir _update_symlinks" ]]
 
     run vagga _compgen -- _r
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "_run _run_in_netns _relative_work_dir" ]]
 
     run vagga _compgen -- _ran
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "" ]]
 
     run vagga _compgen _build --
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "data ubuntu" ]]
 
     run vagga _compgen _build -- -
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "--force" ]]
 
     run vagga _compgen _build -- --
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "--force" ]]
 
     run vagga _compgen _build --force --
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "data ubuntu" ]]
 
     run vagga _compgen _run --
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "ubuntu" ]]
 
     run vagga _compgen _run -- -
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "-W --writable --no-image-download --no-build \
 --no-version-check" ]]
 
     run vagga _compgen _run -- --
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "--writable --no-image-download --no-build \
 --no-version-check" ]]
 
     run vagga _compgen _run -- u
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "ubuntu" ]]
 
     run vagga _compgen _run -W --
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "ubuntu" ]]
 
     run vagga _compgen --use-env HOME _run --writable -- u
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "ubuntu" ]]
 
     run vagga _compgen _run -- ud
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "" ]]
 
     run vagga _compgen _run unknown_container --
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "" ]]
 }

--- a/tests/composer.bats
+++ b/tests/composer.bats
@@ -10,7 +10,6 @@ teardown() {
 # test composer is available in PATH and removed after container is built
 @test "composer: lifecycle" {
     run vagga _build composer-lifecycle
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = *"Composer version"* ]]
     [[ ! -f ".vagga/composer-lifecycle/usr/local/bin/composer" ]]
@@ -20,14 +19,12 @@ teardown() {
 
 @test "composer: keep composer after build" {
     run vagga _build keep-composer
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ -f .vagga/keep-composer/usr/local/bin/composer ]]
 }
 
 @test "composer: change vendor directory" {
     run vagga _build change-vendor-dir
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ -d .vagga/change-vendor-dir/usr/local/dependencies/vendor/nette/tester ]]
 }
@@ -36,7 +33,6 @@ teardown() {
 
 @test "composer: php ubuntu xenial" {
     run vagga _run php-ubuntu-xenial laravel --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer 1.3.0" ]]
     link=$(readlink .vagga/php-ubuntu-xenial)
@@ -45,7 +41,6 @@ teardown() {
 
 @test "composer: php ubuntu trusty" {
     run vagga _run php-ubuntu-trusty laravel --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer 1.3.0" ]]
     link=$(readlink .vagga/php-ubuntu-trusty)
@@ -54,7 +49,6 @@ teardown() {
 
 @test "composer: php ubuntu focal" {
     run vagga _run php-ubuntu-focal tester .
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "No tests found" ]]
     link=$(readlink .vagga/php-ubuntu-focal)
@@ -63,7 +57,6 @@ teardown() {
 
 @test "composer: php alpine 3.5" {
     run vagga _run php-alpine-3_5 laravel --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer 1.3.0" ]]
     link=$(readlink .vagga/php-alpine-3_5)
@@ -72,12 +65,10 @@ teardown() {
 
 @test "composer: php alpine 3.5 php7" {
     run vagga _run php-alpine-3_5-php7 php --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-3]} = "PHP 7.0."*" (cli)"* ]]
 
     run vagga _run php-alpine-3_5-php7 laravel --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer 1.3.0" ]]
 
@@ -87,7 +78,6 @@ teardown() {
 
 @test "composer: php alpine 3.4" {
     run vagga _run php-alpine-3_4 laravel --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer 1.3.0" ]]
     link=$(readlink .vagga/php-alpine-3_4)
@@ -96,7 +86,6 @@ teardown() {
 
 @test "composer: php alpine 3.3" {
     run vagga _run php-alpine-3_3 laravel --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer 1.3.0" ]]
     link=$(readlink .vagga/php-alpine-3_3)
@@ -105,7 +94,6 @@ teardown() {
 
 @test "composer: php alpine 3.2" {
     run vagga _run php-alpine-3_2 laravel --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer 1.3.0" ]]
     link=$(readlink .vagga/php-alpine-3_2)
@@ -114,7 +102,6 @@ teardown() {
 
 @test "composer: php ComposerDependencies alpine 3.5" {
     run vagga _run php-composer-deps-alpine-3_5 laravel --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer version 1.3.0" ]]
     link=$(readlink .vagga/php-composer-deps-alpine-3_5)
@@ -123,12 +110,10 @@ teardown() {
 
 @test "composer: php ComposerDependencies alpine 3.5 php7" {
     run vagga _run php-alpine-3_5-php7 php --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-3]} = "PHP 7.0."*" (cli)"* ]]
 
     run vagga _run php-composer-deps-alpine-3_5-php7 laravel --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer version 1.3.0" ]]
 
@@ -138,7 +123,6 @@ teardown() {
 
 @test "composer: php ComposerDependencies alpine 3.4" {
     run vagga _run php-composer-deps laravel --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer version 1.3.0" ]]
     link=$(readlink .vagga/php-composer-deps)
@@ -147,7 +131,6 @@ teardown() {
 
 @test "composer: php ComposerDependencies ubuntu xenial" {
     run vagga _run php-composer-deps-ubuntu-xenial laravel --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer version 1.3.0" ]]
     link=$(readlink .vagga/php-composer-deps-ubuntu-xenial)
@@ -156,7 +139,6 @@ teardown() {
 
 @test "composer: php ComposerDependencies ubuntu trusty" {
     run vagga _run php-composer-deps-ubuntu-trusty laravel --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer version 1.3.0" ]]
     link=$(readlink .vagga/php-composer-deps-ubuntu-trusty)
@@ -165,7 +147,6 @@ teardown() {
 
 @test "composer: php ComposerDependencies dev" {
     run vagga _run php-composer-dev-deps task greet
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Hello, Vagga!" ]]
     link=$(readlink .vagga/php-composer-dev-deps)
@@ -174,7 +155,6 @@ teardown() {
 
 @test "composer: php ComposerDependencies dev ubuntu xenial" {
     run vagga _run php-composer-dev-deps-ubuntu-xenial task greet
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Hello, Vagga!" ]]
     link=$(readlink .vagga/php-composer-dev-deps-ubuntu-xenial)
@@ -183,7 +163,6 @@ teardown() {
 
 @test "composer: php ComposerDependencies dev ubuntu trusty" {
     run vagga _run php-composer-dev-deps-ubuntu-trusty task greet
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Hello, Vagga!" ]]
     link=$(readlink .vagga/php-composer-dev-deps-ubuntu-trusty)
@@ -192,7 +171,6 @@ teardown() {
 
 @test "composer: php ComposerDependencies prefer dist" {
     run vagga _run php-composer-deps-prefer-dist task greet
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Hello, Vagga!" ]]
     link=$(readlink .vagga/php-composer-deps-prefer-dist)
@@ -201,7 +179,6 @@ teardown() {
 
 @test "composer: php ComposerDependencies wrong prefer" {
     run vagga _build php-composer-deps-wrong-prefer
-    printf "%s\n" "${lines[@]}"
     [[ $status = 121 ]]
     [[ $output = *"Value of 'ComposerDependencies.prefer' must be either 'source' or 'dist', 'wrong' given"* ]]
 }
@@ -209,7 +186,6 @@ teardown() {
 @test "composer: php ComposerDependencies lock" {
     cd /work/tests/composer_lock
     run vagga _run php-composer-deps-lock laravel --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = *"The lock file is not up to date with the latest changes in composer.json"* ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer version 1.3.0" ]]
@@ -222,7 +198,6 @@ teardown() {
 @test "composer: hhvm ubuntu xenial" {
     skip "Something wrong with default hhvm package on ubuntu"
     run vagga _run hhvm-ubuntu-xenial laravel --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Laravel Installer 1.3.0" ]]
     link=$(readlink .vagga/hhvm-ubuntu-xenial)

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -4,18 +4,15 @@ setup() {
 
 @test "copy: directory" {
     run vagga _build dir-copy
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/dir-copy)
     [[ $link = ".roots/dir-copy.781a47c8/root" ]]
 
     run vagga test-dir
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "world file sub" ]]
 
     run vagga _run dir-copy /var/dir/exe.sh
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = "Hello!" ]]
 
@@ -35,7 +32,6 @@ setup() {
     [[ $link = ".roots/file-copy.7ad83313/root" ]]
 
     run vagga test-file
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} = "data" ]]
 
@@ -44,7 +40,6 @@ setup() {
 
 @test "copy: non work" {
     run vagga _build copy-non-work
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/copy-non-work)
     [[ $link = ".roots/copy-non-work.5d99d983/root" ]]
@@ -55,7 +50,6 @@ setup() {
 
 @test "copy: non work preserve permissions" {
     run vagga _build copy-non-work-preserve-perms
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/copy-non-work-preserve-perms)
     [[ $link = ".roots/copy-non-work-preserve-perms.0a69e70c/root" ]]
@@ -68,7 +62,6 @@ setup() {
 
 @test "copy: with umask" {
     run vagga _build copy-umask
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/copy-umask)
     [[ $link = ".roots/copy-umask.98755219/root" ]]
@@ -85,7 +78,6 @@ setup() {
     chmod -R o-rwx dir
 
     run vagga _build copy-preserve-perms
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/copy-preserve-perms)
     [[ $link = ".roots/copy-preserve-perms.ce6b370a/root" ]]
@@ -99,13 +91,11 @@ setup() {
 
 @test "copy: clean _unused (non-existent)" {
     run vagga _clean --unused
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
 }
 
 @test "copy: include regex" {
     run vagga _build copy-with-include
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/copy-with-include)
     [[ $link = ".roots/copy-with-include.c7333188/root" ]]
     [[ -f ".vagga/copy-with-include/dir/hello" ]]
@@ -117,7 +107,6 @@ setup() {
 
 @test "copy: glob rules" {
     run vagga _build copy-glob-rules
-    printf "%s\n" "${lines[@]}"
     root=".vagga/copy-glob-rules"
     link=$(readlink $root)
     [[ $link = ".roots/copy-glob-rules.c7333188/root" ]]
@@ -130,7 +119,6 @@ setup() {
 
 @test "copy: glob rules with inverse" {
     run vagga _build copy-glob-rules-inverse
-    printf "%s\n" "${lines[@]}"
     root=".vagga/copy-glob-rules-inverse"
     link=$(readlink $root)
     [[ $link = ".roots/copy-glob-rules-inverse.981e78a1/root" ]]
@@ -141,7 +129,6 @@ setup() {
 
 @test "copy: glob no include rules" {
     run vagga _build copy-glob-no-include-rules
-    printf "%s\n" "${lines[@]}"
     root=".vagga/copy-glob-no-include-rules"
     link=$(readlink $root)
     [[ $link = ".roots/copy-glob-no-include-rules.ee039a4f/root" ]]
@@ -155,29 +142,24 @@ setup() {
 
 @test "depends: include regex" {
     run vagga _version_hash --short depends-with-include
-    printf "%s\n" "${lines[@]}"
     [[ $output = "375d1004" ]]
 
     chmod 0755 dir/subdir
     run vagga _version_hash --short depends-with-include
-    printf "%s\n" "${lines[@]}"
     [[ $output = "375d1004" ]]
 }
 
 @test "depends: glob rules" {
     run vagga _version_hash --short depends-glob-rules
-    printf "%s\n" "${lines[@]}"
     [[ $output = "375d1004" ]]
 
     chmod 0755 dir/subdir
     run vagga _version_hash --short depends-glob-rules
-    printf "%s\n" "${lines[@]}"
     [[ $output = "375d1004" ]]
 }
 
 @test "copy: preserve times" {
     run vagga _build copy-preserve-times
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/copy-preserve-times)
     [[ $link = ".roots/copy-preserve-times.6ca4b065/root" ]]

--- a/tests/cyclic.bats
+++ b/tests/cyclic.bats
@@ -4,7 +4,6 @@ setup() {
 
 @test "cyclic: Crash prevention" {
     run vagga crash-me-not
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 126 ]]
     [[ ${lines[${#lines[@]}-1]} = 'Container "crash" has cyclic dependency' ]]
 }

--- a/tests/gem_bundler.bats
+++ b/tests/gem_bundler.bats
@@ -10,7 +10,6 @@ teardown() {
 
 @test "gem/bundler: alpine pkg" {
     run vagga _run pkg-alpine rake --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "rake, version 11.1.1" ]]
     link=$(readlink .vagga/pkg-alpine)
@@ -19,7 +18,6 @@ teardown() {
 
 @test "gem/bundler: alpine pkg no update gem" {
     run vagga _run pkg-alpine-no-update-gem rake --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "rake, version 11.1.1" ]]
     link=$(readlink .vagga/pkg-alpine-no-update-gem)
@@ -28,7 +26,6 @@ teardown() {
 
 @test "gem/bundler: ubuntu focal pkg" {
     run vagga _run pkg-ubuntu-focal fpm --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "1.14.1" ]]
     link=$(readlink .vagga/pkg-ubuntu-focal)
@@ -37,7 +34,6 @@ teardown() {
 
 @test "gem/bundler: ubuntu focal pkg no update gem" {
     run vagga _run pkg-ubuntu-focal-no-update-gem fpm --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "1.14.1" ]]
     link=$(readlink .vagga/pkg-ubuntu-focal-no-update-gem)
@@ -46,7 +42,6 @@ teardown() {
 
 @test "gem/bundler: ubuntu bionic pkg" {
     run vagga _run pkg-ubuntu-bionic fpm --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "1.14.1" ]]
     link=$(readlink .vagga/pkg-ubuntu-bionic)
@@ -55,7 +50,6 @@ teardown() {
 
 @test "gem/bundler: ubuntu bionic pkg no update gem" {
     run vagga _run pkg-ubuntu-bionic-no-update-gem fpm --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "1.14.1" ]]
     link=$(readlink .vagga/pkg-ubuntu-bionic-no-update-gem)
@@ -64,7 +58,6 @@ teardown() {
 
 @test "gem/bundler: alpine GemBundle" {
     run vagga _run bundle-alpine fpm --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "1.14.1" ]]
     [[ -d .vagga/bundle-alpine/usr/lib/ruby/gems/2.3.0/gems/cuba-3.9.3 ]]
@@ -75,7 +68,6 @@ teardown() {
 
 @test "gem/bundler: alpine GemBundle without dev" {
     run vagga _build bundle-alpine-no-dev
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ -d .vagga/bundle-alpine-no-dev/usr/lib/ruby/gems/2.3.0/gems/cuba-3.9.3 ]]
     [[ ! -d .vagga/bundle-alpine-no-dev/usr/lib/ruby/gems/2.3.0/gems/fpm-1.14.1 ]]
@@ -85,7 +77,6 @@ teardown() {
 
 @test "gem/bundler: ubuntu GemBundle" {
     run vagga _run bundle-ubuntu fpm --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "1.14.1" ]]
     [[ -d .vagga/bundle-ubuntu/var/lib/gems/2.7.0/gems/cuba-3.9.3 ]]
@@ -96,7 +87,6 @@ teardown() {
 
 @test "gem/bundler: ubuntu GemBundle without dev" {
     run vagga _build bundle-ubuntu-no-dev
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ -d .vagga/bundle-ubuntu-no-dev/var/lib/gems/2.7.0/gems/cuba-3.9.3 ]]
     [[ ! -d .vagga/bundle-ubuntu-no-dev/var/lib/gems/2.7.0/gems/fpm-1.14.1 ]]
@@ -106,7 +96,6 @@ teardown() {
 
 @test "gem/bundler: GemBundle invalid trust_policy" {
     run vagga _build bundle-invalid-trust-policy
-    printf "%s\n" "${lines[@]}"
     [[ $status = 121 ]]
     [[ $output = *"Value of 'GemBundle.trust_policy' must be 'LowSecurity', 'MediumSecurity' or 'HighSecurity', 'invalid' given"* ]]
 }

--- a/tests/gem_bundler_lock.bats
+++ b/tests/gem_bundler_lock.bats
@@ -9,10 +9,8 @@ teardown() {
 
 @test "gem/bundler_lock: GemBundle lock" {
     run vagga _run bundle-lock rake --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "rake, version 11.1.0" ]]
     link=$(readlink .vagga/bundle-lock)
-    printf "link: %s\n" "$link"
     [[ $link = ".roots/bundle-lock.fe593b9a/root" ]]
 }

--- a/tests/generic.bats
+++ b/tests/generic.bats
@@ -4,7 +4,6 @@ setup() {
 
 @test "generic: The Text tag works" {
     run vagga _run text cat /etc/shakespeare
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/text)
     [[ $link = ".roots/text.efc9a869/root" ]]
     [[ ${lines[${#lines[@]}-2]} = "Sir, in my heart there was a kind of fighting" ]]
@@ -13,33 +12,26 @@ setup() {
 
 @test "generic: Snapshot volume works" {
     run vagga _run moretext cat /etc/shakespeare
-    printf "%s\n" "${lines[@]}"
     [[ ${lines[${#lines[@]}-2]} = "Sir, in my heart there was a kind of fighting" ]]
     [[ ${lines[${#lines[@]}-1]} = "That would not let me sleep." ]]
 
     run vagga replace-shake
-    printf "%s\n" "${lines[@]}"
     [[ ${lines[${#lines[@]}-1]} = "nope" ]]
 
     run vagga _run moretext cat /etc/shakespeare
-    printf "%s\n" "${lines[@]}"
     [[ ${lines[${#lines[@]}-2]} = "Sir, in my heart there was a kind of fighting" ]]
     [[ ${lines[${#lines[@]}-1]} = "That would not let me sleep." ]]
 
     run vagga _build snapshot-check-mode
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     run vagga _run snapshot-check-mode stat -c "%a %U" /home/hemingway
-    printf "%s\n" "${lines[@]}"
     [[ $output = "700 hemingway" ]]
     run vagga _run snapshot-check-mode stat -c "%a %U" /home/hemingway/quote.txt
-    printf "%s\n" "${lines[@]}"
     [[ $output = "644 root" ]]
 }
 
 @test "generic: Snapshot from container" {
     run vagga _run snapshot-container cat /etc/shakespeare
-    printf "%s\n" "${lines[@]}"
     [[ ${lines[${#lines[@]}-2]} = "Sir, in my heart there was a kind of fighting" ]]
     [[ ${lines[${#lines[@]}-1]} = "That would not let me sleep." ]]
 }
@@ -47,20 +39,17 @@ setup() {
 @test "generic: Overriding container volumes" {
     rm -f etc/shakespeare
     run vagga override-volumes
-    printf "%s\n" "${lines[@]}"
     [[ ${lines[${#lines[@]}-1]} = "yeah" ]]
     [[ $(cat etc/shakespeare) = "yeah" ]]
 
     rm -f etc/shakespeare
     run vagga override-volumes-supervise
-    printf "%s\n" "${lines[@]}"
     [[ ${lines[${#lines[@]}-2]} = "yeah" ]]
     [[ $(cat etc/shakespeare) = "yeah" ]]
 }
 
 @test "generic: The CacheDirs tag works" {
     run vagga _run cache_dirs echo ok
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/cache_dirs)
     [[ $link = ".roots/cache_dirs.2090f8c2/root" ]]
     [[ ${lines[${#lines[@]}-1]} = "ok" ]]
@@ -68,7 +57,6 @@ setup() {
 
 @test "generic: The EnsureDir tag works" {
     run vagga _run ensure_dir echo ok
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/ensure_dir)
     [[ $link = ".roots/ensure_dir.998c9d5b/root" ]]
     [[ ${lines[${#lines[@]}-1]} = "ok" ]]
@@ -79,7 +67,6 @@ setup() {
 
 @test "generic: Remove step" {
     run vagga _build remove
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/remove)
     [[ $link = ".roots/remove.2257142d/root" ]]
 
@@ -88,7 +75,6 @@ setup() {
 
 @test "generic: The data-dirs option works" {
     run vagga _build data-container
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/data-container)
     [[ $link = ".roots/data-container.e6da9e30/root" ]]
     [[ -d ".vagga/data-container/etc" ]]
@@ -106,7 +92,6 @@ setup() {
 
 @test "generic: The supervise command works" {
     run vagga two-lines
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/busybox)
     [[ $link = ".roots/busybox.d304a005/root" ]]
     [[ ${lines[${#lines[@]}-3]} = "hello" ]]
@@ -115,7 +100,6 @@ setup() {
 
 @test "generic: The supervise wait-all-successful command works" {
     run vagga wait-all
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/busybox)
     [[ $link = ".roots/busybox.d304a005/root" ]]
     [[ ${lines[${#lines[@]}-2]} = "hello" ]]
@@ -124,7 +108,6 @@ setup() {
 
 @test "generic: The supervise fail-fast works" {
     run vagga one-kills-another
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/busybox)
     [[ ${lines[${#lines[@]}-4]} = "hello" ]]
     [[ ${lines[${#lines[@]}-3]} = "hello" ]]
@@ -133,44 +116,37 @@ setup() {
 
 @test "generic: The supervise --only" {
     run vagga two-lines --only first-line
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/busybox)
     [[ ${lines[${#lines[@]}-2]} = "hello" ]]
 
     run vagga two-lines --only second-line
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/busybox)
     [[ ${lines[${#lines[@]}-2]} = "world" ]]
 }
 
 @test "generic: The supervice --only with tags" {
     run sh -c 'vagga tagged --only first_and_third | sort'
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/busybox)
     [[ ${lines[${#lines[@]}-2]} = ":)" ]]
     [[ ${lines[${#lines[@]}-1]} = "hello" ]]
 
     run sh -c "vagga tagged --only first_and_second | sort"
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/busybox)
     [[ ${lines[${#lines[@]}-2]} = "hello" ]]
     [[ ${lines[${#lines[@]}-1]} = "world" ]]
 
     run sh -c "vagga tagged --only third_only | sort"
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/busybox)
     [[ ${lines[${#lines[@]}-1]} = ":)" ]]
 }
 
 @test "generic: The supervice --only mixed" {
     run sh -c 'vagga tagged --only first first_and_second  | sort'
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/busybox)
     [[ ${lines[${#lines[@]}-2]} = "hello" ]]
     [[ ${lines[${#lines[@]}-1]} = "world" ]]
 
     run vagga tagged --only third first_and_second
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/busybox)
     [[ ${lines[${#lines[@]}-4]} = "hello" ]]
     [[ ${lines[${#lines[@]}-3]} = "world" ]]
@@ -179,29 +155,24 @@ setup() {
 
 @test "generic: The supervise --exclude" {
     run vagga two-lines --exclude second-line
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/busybox)
     [[ ${lines[${#lines[@]}-2]} = "hello" ]]
 
     run vagga two-lines --exclude first-line
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/busybox)
     [[ ${lines[${#lines[@]}-2]} = "world" ]]
 }
 
 @test "generic: The supervice --exclude with tags" {
     run vagga tagged --exclude first_and_third
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/busybox)
     [[ ${lines[${#lines[@]}-2]} = "world" ]]
 
     run vagga tagged --exclude first_and_second
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/busybox)
     [[ ${lines[${#lines[@]}-2]} = ":)" ]]
 
     run vagga tagged --exclude third_only
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/busybox)
     [[ ${lines[${#lines[@]}-3]} = "hello" ]]
     [[ ${lines[${#lines[@]}-2]} = "world" ]]
@@ -209,12 +180,10 @@ setup() {
 
 @test "generic: The supervice --exclude mixed" {
     run vagga tagged --exclude first first_and_second
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/busybox)
     [[ ${lines[${#lines[@]}-2]} = ":)" ]]
 
     run vagga tagged --exclude first_and_third third_only
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/busybox)
     [[ ${lines[${#lines[@]}-2]} = "world" ]]
 }
@@ -222,7 +191,6 @@ setup() {
 @test "generic: isolated Command" {
     vagga _build busybox
     run vagga isolated-command
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $(echo "$output" | grep "^[0-9]*:" | wc -l) = 1 ]]
 }
@@ -230,7 +198,6 @@ setup() {
 @test "generic: isolated _run" {
     vagga _build busybox
     run vagga --no-network _run busybox ip link
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $(echo "$output" | grep "^[0-9]*:" | wc -l) = 1 ]]
 }
@@ -238,7 +205,6 @@ setup() {
 @test "generic: isolated Supervise" {
     vagga _build busybox
     run vagga isolated-supervise
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $(echo "$output" | grep "^[0-9]*:" | wc -l) = 1 ]]
 }
@@ -246,34 +212,29 @@ setup() {
 @test "generic: Supervise with --isolate-network option" {
     vagga _build busybox
     run vagga --no-net not-isolated-supervise
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $(echo "$output" | grep "^[0-9]*:" | wc -l) = 1 ]]
 }
 
 @test "generic: proxy forwards into build" {
     ftp_proxy=ftp://test.server run vagga _build --force printenv
-    printf "%s\n" "${lines[@]}"
     [[ $(printf "%s\n" "${lines[@]}" | grep '^ftp_proxy') = \
         "ftp_proxy=ftp://test.server" ]]
 }
 
 @test "generic: proxy forwards into the run" {
     ftp_proxy=ftp://test.server run vagga --no-build _run printenv env
-    printf "%s\n" "${lines[@]}"
     [[ $(printf "%s\n" "${lines[@]}" | grep '^ftp_proxy') = \
         "ftp_proxy=ftp://test.server" ]]
 }
 
 @test "generic: check for environment variable name validity" {
     run vagga -e key=value printenv
-    printf "%s\n" "${lines[@]}"
     [[ ${lines[${#lines[@]}-2]} = 'Error propagating environment: Environment variable name (for option `-e`/`--use-env`) can'"'"'t contain equals `=` character. To set key-value pair use `-E`/`--environ` option' ]]
 }
 
 @test "generic: unpack local tar" {
     run vagga vagga --version
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/vagga)
     [[ ${lines[${#lines[@]}-1]} = 'v0.4.0' ]]
     [[ $link = ".roots/vagga.03319fd2/root" ]]
@@ -281,7 +242,6 @@ setup() {
 
 @test "generic: download broken file" {
     run vagga _build download-broken-file
-    printf "%s\n" "${lines[@]}"
     [[ $status = 121 ]]
     [[ $output = *"Hashsum mismatch"* ]]
 }
@@ -293,7 +253,6 @@ setup() {
     tar czf tmp.tar.gz tmp/test
 
     run vagga _build tar-no-intermediate-dir
-    printf "%s\n" "${lines[@]}"
     root=".vagga/tar-no-intermediate-dir"
     link=$(readlink "${root}")
     [[ $link = ".roots/tar-no-intermediate-dir.f5b7e571/root" ]]
@@ -310,7 +269,6 @@ setup() {
     tar czf tmp.tar.gz tmp
 
     run vagga _build sys-dirs
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/sys-dirs)
     [[ $link = ".roots/sys-dirs.e66f72fd/root" ]]
     [[ $(stat -c "%a" ".vagga/sys-dirs/dev") = "755" ]]
@@ -325,7 +283,6 @@ setup() {
 
 @test "generic: test system dirs when building container" {
     run vagga _build build-sys-dirs
-    printf "%s\n" "${lines[@]}"
     [[ $output = *"/dev "* ]]
     [[ $output = *"/proc "* ]]
     [[ $output = *"/sys "* ]]
@@ -341,7 +298,6 @@ setup() {
     rm -f $cached_file
 
     run vagga _build unzip-local
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/unzip-local)
     [[ $link = ".roots/unzip-local.9579aef7/root" ]]
     [[ $(cat .vagga/unzip-local/root/test/1/dir/file.txt) = "Hello" ]]
@@ -364,7 +320,6 @@ setup() {
     [[ ! -f $cached_file ]]
 
     run vagga _build unzip-downloaded
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/unzip-downloaded)
     [[ $link = ".roots/unzip-downloaded.fae32fd7/root" ]]
     [[ $(cat .vagga/unzip-downloaded/root/test/dir/file.txt) = "Hello" ]]
@@ -372,13 +327,11 @@ setup() {
     [[ -f $cached_file ]]
 
     run vagga _build unzip-no-subdir
-    printf "%s\n" "${lines[@]}"
     [[ $status = 121 ]]
     [[ $output = *'./dir" is not found in archive'* ]]
     [[ -f test-file.zip ]]
 
     run vagga _build unzip-mismatch-hashsum
-    printf "%s\n" "${lines[@]}"
     [[ $status = 121 ]]
     [[ $output = *"Hashsum mismatch: expected 12345678 but was ${hash}"* ]]
     [[ -f test-file.zip ]]
@@ -388,26 +341,22 @@ setup() {
 
 @test "generic: Container volume works" {
     run vagga snoop
-    printf "%s\n" "${lines[@]}"
     [[ ${lines[${#lines[@]}-2]} = "Sir, in my heart there was a kind of fighting" ]]
     [[ ${lines[${#lines[@]}-1]} = "That would not let me sleep." ]]
 }
 
 @test "generic: The vagga -m works" {
     run vagga -m hello world
-    printf "%s\n" "${lines[@]}"
     [[ ${lines[${#lines[@]}-1]} = "helloworld!" ]]
 }
 
 @test "generic: Hello from fake user" {
     run vagga fake-user
-    printf "%s\n" "${lines[@]}"
     [[ ${lines[${#lines[@]}-1]} = "uid=1(bin) gid=0(root)" ]]
 }
 
 @test "generic: RunAs" {
     run vagga _build run-as
-    printf "%s\n" "${lines[@]}"
     link=$(readlink ".vagga/run-as")
     [[ $link = ".roots/run-as.b0a77478/root" ]]
 
@@ -431,7 +380,6 @@ setup() {
 
 @test "generic: isolated RunAs" {
     run vagga _build isolated-run-as
-    printf "%s\n" "${lines[@]}"
     root=".vagga/isolated-run-as"
     link=$(readlink "${root}")
     [[ $link = ".roots/isolated-run-as.832bc83e/root" ]]
@@ -447,7 +395,6 @@ setup() {
 
 @test "generic: isolated RunAs with external user" {
     run vagga _build isolated-run-as-with-external-uid
-    printf "%s\n" "${lines[@]}"
     root=".vagga/isolated-run-as-with-external-uid"
     link=$(readlink "${root}")
     [[ $link = ".roots/isolated-run-as-with-external-uid.59a8d2d6/root" ]]
@@ -458,19 +405,15 @@ setup() {
 @test "generic: Tmpfs Subdirs" {
     vagga _build tmpfs-subdirs
     run vagga _run tmpfs-subdirs stat -c "%A" /tmp
-    printf "%s\n", "${lines[@]}"
     [[ $output = "drwxrwxrwt" ]]
     run vagga _run tmpfs-subdirs stat -c "%A" /tmp/x
-    printf "%s\n", "${lines[@]}"
     [[ $output = "drwxr-xr-x" ]]
     run vagga _run tmpfs-subdirs stat -c "%A" /tmp/y
-    printf "%s\n", "${lines[@]}"
     [[ $output = "drwx------" ]]
 }
 
 @test "generic: Path precedence" {
     run vagga _run path-precedence hello
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/path-precedence)
     [[ $link = ".roots/path-precedence.e2636a55/root" ]]
     [[ ${lines[${#lines[@]}-1]} = "Hello world!" ]]
@@ -478,7 +421,6 @@ setup() {
 
 @test "generic: Environ precedence" {
     run vagga _build environ
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/environ)
     [[ $link = ".roots/environ.d304a005/root" ]]
 
@@ -516,19 +458,16 @@ site_settings:
 
 @test "generic: Argument parsing for supervise" {
     run sh -c 'vagga args -Fhello --second "world"  | sort'
-    printf "%s\n" "${lines[@]}"
     [[ ${lines[${#lines[@]}-2]} = "hello" ]]
     [[ ${lines[${#lines[@]}-1]} = "world" ]]
 
     run sh -c 'vagga args --first=x --second="y" | sort'
-    printf "%s\n" "${lines[@]}"
     [[ ${lines[${#lines[@]}-2]} = "x" ]]
     [[ ${lines[${#lines[@]}-1]} = "y" ]]
 }
 
 @test "generic: Argument parsing for normal command" {
     run vagga cmdargs -vvvv --verbose
-    printf "%s\n" "${lines[@]}"
     # ensure arguments is not passed directly
     [[ ${lines[${#lines[@]}-2]} = "Args:" ]]
     [[ ${lines[${#lines[@]}-1]} = "Verbosity: 5" ]]
@@ -536,33 +475,27 @@ site_settings:
 
 @test "generic: Help with 'options'" {
     run vagga cmdargs --help
-    printf "%s\n" "${lines[@]}"
     [[ "$status" -eq 0 ]]
 
     run vagga args --help
-    printf "%s\n" "${lines[@]}"
     [[ "$status" -eq 0 ]]
 }
 
 @test "generic: Bad arguments for command with 'options'" {
     run vagga args --bad-arg
-    printf "%s\n" "${lines[@]}"
     [[ "$status" -eq 121 ]]
     [[ ${lines[${#lines[@]}-2]} = "Unknown flag: '--bad-arg'" ]]
     [[ ${lines[${#lines[@]}-1]} = "Usage: vagga args [options]" ]]
 
     run vagga cmdargs --bad-arg
-    printf "%s\n" "${lines[@]}"
     [[ "$status" -eq 121 ]]
     [[ ${lines[${#lines[@]}-1]} = "Usage: vagga cmdargs [options]" ]]
 
     run vagga args extra-arg
-    printf "%s\n" "${lines[@]}"
     [[ "$status" -eq 121 ]]
     [[ ${lines[${#lines[@]}-1]} = "Usage: vagga args [options]" ]]
 
     run vagga cmdargs extra-arg
-    printf "%s\n" "${lines[@]}"
     [[ "$status" -eq 121 ]]
     [[ ${lines[${#lines[@]}-1]} = "Usage: vagga cmdargs [options]" ]]
 }
@@ -577,7 +510,6 @@ site_settings:
     cd ..
     umount tmp
     rm -rf tmp
-    printf "%s\n" "${lines[@]}"
     [[ $status = 1 ]]
     # check there is no "Failed to remount readonly root" warning
     [[ $output != *"Failed to remount"* ]]
@@ -586,7 +518,6 @@ site_settings:
 
 @test "generic: resolv-file-path & hosts-file-path" {
     run vagga _build resolv-conf-and-hosts
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/resolv-conf-and-hosts)
     [[ $link = ".roots/resolv-conf-and-hosts.57222830/root" ]]
@@ -598,14 +529,12 @@ site_settings:
     [[ $hosts_link = "/state/hosts" ]]
 
     run vagga _run resolv-conf-and-hosts cat /state/resolv.conf
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $(cat /etc/resolv.conf) = $output ]]
 }
 
 @test "generic: alternate shell (bash)" {
     run vagga bash-shell
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = '\"hello\"' ]]
 }

--- a/tests/hardlinking.bats
+++ b/tests/hardlinking.bats
@@ -10,13 +10,11 @@ setup() {
     "
 
     run vagga _build hello
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/hello)
     [[ $link = ".roots/hello.0ae0aab6/root" ]]
 
     run vagga _build hello-and-bye
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/hello-and-bye)
     [[ $link = ".roots/hello-and-bye.84b3175b/root" ]]
@@ -25,7 +23,6 @@ setup() {
 
     sed -i 's/!/?/' .vagga/hello/etc/hello.txt
     run vagga _build --force hello-and-bye
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/hello-and-bye)
     [[ $link = ".roots/hello-and-bye.84b3175b/root" ]]
@@ -48,7 +45,6 @@ setup() {
     cd /work/tests/hardlinking/project-1
     rm -rf .vagga
     run vagga _build hello
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/hello)
     [[ $link = ".lnk/.roots/hello.0ae0aab6/root" ]]
@@ -56,7 +52,6 @@ setup() {
     cd /work/tests/hardlinking/project-2
     rm -rf .vagga
     run vagga _build hello-and-bye
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/hello-and-bye)
     [[ $link = ".lnk/.roots/hello-and-bye.84b3175b/root" ]]
@@ -66,24 +61,20 @@ setup() {
 @test "_hardlink cmd" {
     rm -rf .vagga
     run vagga _build hello
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/hello)
     [[ $link = ".roots/hello.0ae0aab6/root" ]]
 
     run vagga _hardlink
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = *"Found and linked 0"* ]]
 
     run vagga _build hello-and-bye
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/hello-and-bye)
     [[ $link = ".roots/hello-and-bye.84b3175b/root" ]]
 
     run vagga _hardlink
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = *"Found and linked 3 (12B) identical files"* ]]
 
@@ -96,7 +87,6 @@ setup() {
     sed -i 's/!/?/' .vagga/hello/etc/hello.txt
     vagga _build --force hello-and-bye
     run vagga _hardlink
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/hello-and-bye)
     [[ $link = ".roots/hello-and-bye.84b3175b/root" ]]
@@ -115,32 +105,27 @@ setup() {
     cd /work/tests/hardlinking/project-1
     rm -rf .vagga
     run vagga _build --force hello
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/hello)
     [[ $link = ".lnk/.roots/hello.0ae0aab6/root" ]]
 
     run vagga _build --force hi
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/hi)
     [[ $link = ".lnk/.roots/hi.079e4655/root" ]]
 
     run vagga _hardlink --global
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = *"Found and linked 2 (0B) identical files"* ]]
 
     cd /work/tests/hardlinking/project-2
     rm -rf .vagga
     run vagga _build --force hello-and-bye
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/hello-and-bye)
     [[ $link = ".lnk/.roots/hello-and-bye.84b3175b/root" ]]
 
     run vagga _hardlink --global
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = *"Found and linked 3 (12B) identical files"* ]]
 }
@@ -151,7 +136,6 @@ setup() {
     vagga _hardlink
 
     run vagga _verify hello
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
 
     echo "Hi!" > .vagga/hello-and-bye/etc/hello.txt
@@ -159,13 +143,11 @@ setup() {
     rm .vagga/hello-and-bye/etc/bye.txt
 
     run vagga _verify hello-and-bye
-    printf "%s\n" "${lines[@]}"
     [[ $status = 1 ]]
     [[ $output = *"Container is corrupted"* ]]
     [[ $output = *"Missing"*"/etc/bye.txt"*"Extra"*"/etc/bonjour.txt"*"Corrupted"*"/etc/hello.txt" ]]
 
     run vagga _verify hello
-    printf "%s\n" "${lines[@]}"
     [[ $status = 1 ]]
     [[ $output = *"Container is corrupted"* ]]
     [[ $output = *"Corrupted"*"/etc/hello.txt"* ]]

--- a/tests/image.bats
+++ b/tests/image.bats
@@ -10,30 +10,24 @@ setup() {
     vagga _pack_image image -f .vagga/images/image.tar.bz2 -j
     vagga _pack_image image -f .vagga/images/image.tar.xz -J
     run file .vagga/images/image.tar
-    printf "%s\n" "${lines[@]}"
     image_tar_hashsum=$(sha256sum .vagga/images/image.tar | cut -d " " -f 1)
     [[ $output = *"image.tar: POSIX tar archive (GNU)"* ]]
     run tar -tf .vagga/images/image.tar
     [[ $output = *"/var/lib/question.txt"* ]]
     run file .vagga/images/image.tar.gz
-    printf "%s\n" "${lines[@]}"
     image_targz_hashsum=$(sha256sum .vagga/images/image.tar.gz | cut -d " " -f 1)
     [[ $output = *"image.tar.gz: gzip compressed data"* ]]
     run file .vagga/images/image.tar.bz2
-    printf "%s\n" "${lines[@]}"
     [[ $output = *"image.tar.bz2: bzip2 compressed data"* ]]
     run file .vagga/images/image.tar.xz
-    printf "%s\n" "${lines[@]}"
     [[ $output = *"image.tar.xz: XZ compressed data"* ]]
 
     vagga _pack_image image > .vagga/images/image-stdout.tar
     vagga _pack_image image -z > .vagga/images/image-stdout.tgz
     run file .vagga/images/image-stdout.tar
-    printf "%s\n" "${lines[@]}"
     [[ $output = *"image-stdout.tar: POSIX tar archive (GNU)"* ]]
     [[ $(sha256sum .vagga/images/image-stdout.tar | cut -d " " -f 1) = $image_tar_hashsum ]]
     run file .vagga/images/image-stdout.tgz
-    printf "%s\n" "${lines[@]}"
     [[ $output = *"image-stdout.tgz: gzip compressed data"* ]]
     [[ $(sha256sum .vagga/images/image-stdout.tgz | cut -d " " -f 1) = $image_targz_hashsum ]]
 }

--- a/tests/inheritance.bats
+++ b/tests/inheritance.bats
@@ -4,7 +4,6 @@ setup() {
 
 @test "inheritance: Deep container" {
     run vagga py
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/pythonic)
     [[ $link = ".roots/pythonic.db184093/root" ]]
@@ -12,7 +11,6 @@ setup() {
 
 @test "inheritance: Run echo command" {
     run vagga echo hello
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
 #    [[ $output = hello ]]
     [[ ${lines[${#lines[@]}-1]} = hello ]]
@@ -22,7 +20,6 @@ setup() {
 
 @test "inheritance: Run bc" {
     run vagga calc 100*24
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "2400" ]]
     link=$(readlink .vagga/calc)
@@ -31,7 +28,6 @@ setup() {
 
 @test "inheritance: Inherit from container with deep structure" {
     run vagga deep-cat
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "world" ]]
     link=$(readlink .vagga/sub)
@@ -40,14 +36,12 @@ setup() {
 
 @test "inheritance: Test hardlink copy of the deep structure" {
     run vagga deep-cat-copy
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "world" ]]
 }
 
 @test "inheritance: Build mount" {
     run vagga hello-mount
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Hello World!" ]]
     link=$(readlink .vagga/hellomount)
@@ -56,7 +50,6 @@ setup() {
 
 @test "inheritance: Build copy from mount" {
     run vagga hello-copy-from-mount
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Hello World!" ]]
     link=$(readlink .vagga/hellocopyfrommount)
@@ -65,7 +58,6 @@ setup() {
 
 @test "inheritance: Build copy" {
     run vagga hello-copy
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Hello World!" ]]
     link=$(readlink .vagga/hellocopy)
@@ -74,7 +66,6 @@ setup() {
 
 @test "inheritance: Build copy contenthash" {
     run vagga hello-copy-ch
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Hello World!" ]]
     link=$(readlink .vagga/hellocopy-contenthash)
@@ -83,17 +74,14 @@ setup() {
 
 @test "inheritance: Build copy rules" {
     run vagga hello-copy-rules
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Hello World!" ]]
     link=$(readlink .vagga/hellocopy-rules)
-    printf "link: %s\n" "$link"
     [[ $link = ".roots/hellocopy-rules.1c88be7f/root" ]]
 }
 
 @test "inheritance: Build copy file" {
     run vagga hello-copy-file
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Hello World!" ]]
     link=$(readlink .vagga/hellocopyfile)
@@ -102,7 +90,6 @@ setup() {
 
 @test "inheritance: Build copy file with contenthash" {
     run vagga hello-copy-file-ch
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "Hello World!" ]]
     link=$(readlink .vagga/hellocopyfile-contenthash)
@@ -111,7 +98,6 @@ setup() {
 
 @test "inheritance: Deep inheritance" {
     run vagga ok
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "10" ]]
     link=$(readlink .vagga/c10)

--- a/tests/mixins.bats
+++ b/tests/mixins.bats
@@ -5,7 +5,6 @@ setup() {
 @test "mixins: Runs original command" {
     run vagga _build alpine
     run vagga top
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = top ]]
 }
@@ -13,7 +12,6 @@ setup() {
 @test "mixins: Overrides command" {
     run vagga _build alpine
     run vagga overrides
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = overrides ]]
 }
@@ -21,7 +19,6 @@ setup() {
 @test "mixins: Overrides in the middle" {
     run vagga _build alpine
     run vagga m1x
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = m2 ]]
 }
@@ -29,7 +26,6 @@ setup() {
 @test "mixins: Mixin command 1" {
     run vagga _build alpine
     run vagga m1
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = m1 ]]
 }
@@ -37,7 +33,6 @@ setup() {
 @test "mixins: Mixin command 2" {
     run vagga _build alpine
     run vagga m2
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = m2 ]]
 }
@@ -45,7 +40,6 @@ setup() {
 @test "mixins: List is correct" {
     run vagga _build alpine
     run vagga _list
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ "${lines[0]}" = "m1                  " ]]
     [[ "${lines[1]}" = "m1x                 " ]]
@@ -57,7 +51,6 @@ setup() {
 @test "mixins: Minimum version warning" {
     cd ../mixins_version
     run vagga _build test
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output != *"UnknownBuildStep"* ]]
     [[ $output = *"Please upgrade vagga"* ]]

--- a/tests/network.bats
+++ b/tests/network.bats
@@ -8,7 +8,6 @@ setup() {
     sleep 0.05
     run vagga connect
     kill %1
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[0]} = "hello world!" ]]
 }
@@ -18,7 +17,6 @@ setup() {
     sleep 0.05
     run vagga connect
     kill %1
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[0]} = "hello world!" ]]
 }

--- a/tests/npm.bats
+++ b/tests/npm.bats
@@ -4,7 +4,6 @@ setup() {
 
 @test "npm: default pkg" {
     run vagga _run pkg resolve .
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = /work ]]
     link=$(readlink .vagga/pkg)
@@ -13,27 +12,22 @@ setup() {
 
 @test "npm: bionic pkg" {
     run vagga _run pkg-bionic resolve .
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = /work ]]
     link=$(readlink .vagga/pkg-bionic)
-    printf "Link:  %s" "$link"
     [[ $link = ".roots/pkg-bionic.75d76405/root" ]]
 }
 
 @test "npm: xenial pkg" {
     run vagga _run pkg-xenial resolve .
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = /work ]]
     link=$(readlink .vagga/pkg-xenial)
-    printf "Link:  %s" "$link"
     [[ $link = ".roots/pkg-xenial.f8666b62/root" ]]
 }
 
 @test "npm: alpine pkg" {
     run vagga _run pkg-alpine resolve .
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = /work ]]
     link=$(readlink .vagga/pkg-alpine)
@@ -42,7 +36,6 @@ setup() {
 
 @test "npm: default git" {
     run vagga _run git resolve .
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = /work ]]
     link=$(readlink .vagga/git)
@@ -51,7 +44,6 @@ setup() {
 
 @test "npm: ubuntu git" {
     run vagga _run git-ubuntu resolve .
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = /work ]]
     link=$(readlink .vagga/git-ubuntu)
@@ -60,7 +52,6 @@ setup() {
 
 @test "npm: alpine git" {
     run vagga _run git-alpine resolve .
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = /work ]]
     link=$(readlink .vagga/git-alpine)
@@ -69,7 +60,6 @@ setup() {
 
 @test "npm: NpmDependencies" {
     run vagga _run npm-deps resolve .
-    printf "%s\n" "${lines[@]}"
     [[ $status = 124 ]]  # no resolve but has classnames --v
     [[ -f .vagga/npm-deps/usr/lib/node_modules/classnames/index.js ]]
     link=$(readlink .vagga/npm-deps)
@@ -77,7 +67,6 @@ setup() {
 }
 @test "npm: NpmDependencies dev" {
     run vagga _run npm-dev-deps resolve .
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = /work ]]
     link=$(readlink .vagga/npm-dev-deps)
@@ -86,7 +75,6 @@ setup() {
 
 @test "npm: unsupported alpine version" {
     run vagga _run pkg-alpine-36 resolve .
-    printf "%s\n" "${lines[@]}"
     [[ $status = 121 ]]
     [[ $output = *"Vagga does not support npm on Alpine v3.6 (use >= v3.9)"* ]]
 }

--- a/tests/pip.bats
+++ b/tests/pip.bats
@@ -4,7 +4,6 @@ setup() {
 
 @test "py2: ubuntu pkg" {
     run vagga _run py2-ubuntu urp -Q key=val http://example.com
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
     link=$(readlink .vagga/py2-ubuntu)
@@ -13,7 +12,6 @@ setup() {
 
 @test "py2: alpine pkg" {
     run vagga _run py2-alpine urp -Q key=val http://example.com
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
     link=$(readlink .vagga/py2-alpine)
@@ -22,7 +20,6 @@ setup() {
 
 @test "py2: ubuntu git" {
     run vagga _run py2-git-ubuntu urp -Q key=val http://example.com
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
     link=$(readlink .vagga/py2-git-ubuntu)
@@ -31,7 +28,6 @@ setup() {
 
 @test "py2: alpine git" {
     run vagga _run py2-git-alpine urp -Q key=val http://example.com
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
     link=$(readlink .vagga/py2-git-alpine)
@@ -40,7 +36,6 @@ setup() {
 
 @test "py3: ubuntu pkg" {
     run vagga _run py3-ubuntu urp -Q key=val http://example.com
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
     link=$(readlink .vagga/py3-ubuntu)
@@ -50,7 +45,6 @@ setup() {
 @test "py3: ubuntu py3.5" {
     vagga _build py35-ubuntu
     run vagga _run py35-ubuntu python3.5 -m urp -Q key=val http://example.com
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
     link=$(readlink .vagga/py35-ubuntu)
@@ -59,7 +53,6 @@ setup() {
 
 @test "py3: ubuntu git" {
     run vagga _run py3-git-ubuntu urp -Q key=val http://example.com
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
     link=$(readlink .vagga/py3-git-ubuntu)
@@ -68,7 +61,6 @@ setup() {
 
 @test "py2: ubuntu req.txt" {
     run vagga _run py2req-ubuntu urp -Q key=val http://example.com
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
     link=$(readlink .vagga/py2req-ubuntu)
@@ -77,7 +69,6 @@ setup() {
 
 @test "py2: alpine req.txt" {
     run vagga _run py2req-alpine urp -Q key=val http://example.com
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
     link=$(readlink .vagga/py2req-alpine)
@@ -86,7 +77,6 @@ setup() {
 
 @test "py3: ubuntu req-https.txt" {
     run vagga _build py3req-https-ubuntu
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/py3req-https-ubuntu)
     [[ $link = ".roots/py3req-https-ubuntu.39fc6dcd/root" ]]
@@ -94,7 +84,6 @@ setup() {
 
 @test "py3: alpine req-https.txt" {
     run vagga _build py3req-https-alpine
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/py3req-https-alpine)
     [[ $link = ".roots/py3req-https-alpine.fb29b883/root" ]]
@@ -102,7 +91,6 @@ setup() {
 
 @test "py3: container inheritance" {
     run vagga _build py3req-inherit
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/py3req-inherit)
     [[ $link = ".roots/py3req-inherit.51b2cf8f/root" ]]
@@ -112,14 +100,12 @@ setup() {
     vagga _build ubuntu-lxml
     vagga _build alpine-lxml
     run vagga _run alpine-lxml python3 -c "from lxml import etree"
-    printf "%s\n" "${lines[@]}"
     echo STATUS "$status"
     [[ $status = 0 ]]
 }
 
 @test "py3: pty works" {
     run vagga pty-output
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = $'pty_copy\r' ]]
 }
@@ -127,23 +113,19 @@ setup() {
 @test "py3: recursive requirements files" {
     echo '-r requirements.txt' > /work/tests/pip/include-short.txt
     run sh -c 'vagga _version_hash py3req-recursive-reqs -s'
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     result="${lines[@]}"
     echo 'injections' >> /work/tests/pip/include-short.txt
     run sh -c 'vagga _version_hash py3req-recursive-reqs -s'
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[@]} != "$result" ]]
     run vagga _run py3req-recursive-reqs python3 -m urp -Q key=val http://example.com
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
 }
 
 @test "py3: pip dependencies" {
     run vagga _build pip-deps
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/pip-deps)
     [[ $link = ".roots/pip-deps.3c5031dd/root" ]]

--- a/tests/prerequisites.bats
+++ b/tests/prerequisites.bats
@@ -5,7 +5,6 @@ setup() {
 
 @test "prerequisites: One prerequisite" {
     run vagga two
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[0]} = "one" ]]
     [[ ${lines[1]} = "two" ]]
@@ -13,7 +12,6 @@ setup() {
 
 @test "prerequisites: Collapsing prerequisites" {
     run vagga four
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[0]} = "one" ]]
     [[ ${lines[1]} = "two" ]]
@@ -23,7 +21,6 @@ setup() {
 
 @test "prerequisites: Force order" {
     run vagga -m three two four
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[0]} = "one" ]]
     [[ ${lines[1]} = "three" ]]
@@ -33,7 +30,6 @@ setup() {
 
 @test "prerequisites: Check persistent volume init" {
     run vagga persistent
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "world" ]]
 }

--- a/tests/subconfig.bats
+++ b/tests/subconfig.bats
@@ -4,7 +4,6 @@ setup() {
 
 @test "subconfig: Run bc" {
     run vagga calc 100*24
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "2400" ]]
     link=$(readlink .vagga/subdir)
@@ -13,7 +12,6 @@ setup() {
 
 @test "subconfig: docker-raw" {
     run vagga _run docker-raw urp -Q key=val http://example.com
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
     link=$(readlink .vagga/docker-raw)
@@ -22,7 +20,6 @@ setup() {
 
 @test "subconfig: docker-smart" {
     run vagga _run docker-smart urp -Q key=val http://example.com
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
     link=$(readlink .vagga/docker-smart)

--- a/tests/ubuntu.bats
+++ b/tests/ubuntu.bats
@@ -16,54 +16,45 @@ setup() {
 
 @test "Run echo command" {
     run vagga echo-cmd hello
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = hello ]]
     run vagga echo-cmd world
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = world ]]
 }
 
 @test "Run echo shell" {
     run vagga echo-shell
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = "" ]]
     run vagga echo-shell hello
-    printf "%s\n" "${lines[@]}"
     [[ $status = 122 ]]
     [[ $output =~ "Unexpected argument" ]]
 }
 
 @test "Run echo shell with arguments" {
     run vagga echo-shell-arg
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = "" ]]
     run vagga echo-shell-arg hello
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = "hello" ]]
 }
 
 @test "Run absent command" {
     run vagga test something
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 121 ]]
     [[ $output =~ 'Command "test" not found and is not an alias' ]]
 }
 
 @test "Check arch support" {
     run vagga check-arch
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = i386 ]]
 }
 
 @test "Run trusty bc" {
     run vagga trusty-calc 100*24
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "2400" ]]
     link=$(readlink .vagga/trusty-calc)
@@ -72,7 +63,6 @@ setup() {
 
 @test "Run xenial bc" {
     run vagga xenial-calc 23*7+3
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "164" ]]
     link=$(readlink .vagga/xenial-calc)
@@ -81,26 +71,22 @@ setup() {
 
 @test "Test BuildDeps with version" {
     run vagga _build build-deps-with-version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = *"480191"* ]]
     link=$(readlink .vagga/build-deps-with-version)
     [[ $link = ".roots/build-deps-with-version.293fcc59/root" ]]
 
     run vagga _run build-deps-with-version bc
-    printf "%s\n" "${lines[@]}"
     [[ $status = 124 ]]
 }
 
 @test "Test focal universe" {
     run vagga _build ubuntu-universe
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     link=$(readlink .vagga/ubuntu-universe)
     [[ $link = ".roots/ubuntu-universe.cf089a9f/root" ]]
 
     run vagga _run ubuntu-universe /usr/games/cowsay "Have you mooed today?"
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = *"Have you mooed today?"* ]]
 }
@@ -131,7 +117,6 @@ setup() {
 
 @test "ubuntu: builddeps needed for other packages" {
     run vagga checkinstall -v
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ $output != "" ]]
     link=$(readlink .vagga/dependency-conflict)
@@ -140,8 +125,6 @@ setup() {
 
 @test "ubuntu: install from ppa" {
     run vagga _run ppa redis-cli --version
-    printf "%s\n" "${lines[@]}"
-    printf "Status: %d\n" "$status"
     [[ $status -eq 0 ]]
     [[ $output != "" ]]
     link=$(readlink .vagga/ppa)
@@ -150,18 +133,14 @@ setup() {
 
 @test "ubuntu: install from ppa in bionic" {
     run vagga _run ppa_bionic redis-cli --version
-    printf "%s\n" "${lines[@]}"
-    printf "Status: %d\n" "$status"
     [[ $status -eq 0 ]]
     [[ $output != "" ]]
     link=$(readlink .vagga/ppa_bionic)
-    printf "Container link $link"
     [[ $link = ".roots/ppa_bionic.85fbff22/root" ]]
 }
 
 @test "ubuntu: UbuntuRepo minimal" {
     run vagga _build ubuntu-repo-minimal
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/ubuntu-repo-minimal)
     [[ $link = ".roots/ubuntu-repo-minimal.4c867b7a/root" ]]
 
@@ -169,14 +148,12 @@ setup() {
     [[ $repo_line = *" xenial universe" ]]
 
     run vagga _run ubuntu-repo-minimal /usr/games/cowsay "Have you mooed today?"
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = *"Have you mooed today?"* ]]
 }
 
 @test "ubuntu: UbuntuRepo full" {
     run vagga _build ubuntu-repo-full
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/ubuntu-repo-full)
     [[ $link = ".roots/ubuntu-repo-full.71fe190e/root" ]]
 
@@ -184,14 +161,12 @@ setup() {
     [[ $repo_line = "deb [trusted=yes] http://ubuntu.zerogw.com vagga main" ]]
 
     run vagga _run ubuntu-repo-full vagga --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = "v0.8.1" ]]
 }
 
 @test "ubuntu: UbuntuRepo https" {
     run vagga _build ubuntu-repo-https-sub
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/ubuntu-repo-https-sub)
     [[ $link = ".roots/ubuntu-repo-https-sub.e23819c1/root" ]]
 
@@ -199,14 +174,12 @@ setup() {
     [[ $repo_line = "deb https://deb.nodesource.com/node_5.x xenial main" ]]
 
     run vagga _run ubuntu-repo-https-sub node --version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = "v5."* ]]
 }
 
 @test "ubuntu: Repo simple" {
     run vagga _build repo-simple
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/repo-simple)
     [[ $link = ".roots/repo-simple.382949ab/root" ]]
 
@@ -214,13 +187,11 @@ setup() {
     [[ $repo_line = *" xenial universe" ]]
 
     run vagga _run repo-simple banner Wonderful
-    printf "%s\n" "${lines[@]}"
     [[ $output = "#     #"* ]]
 }
 
 @test "ubuntu: Repo with suite" {
     run vagga _build repo-with-suite
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/repo-with-suite)
     [[ $link = ".roots/repo-with-suite.31742766/root" ]]
 
@@ -228,12 +199,10 @@ setup() {
     [[ $repo_line = *" xenial universe" ]]
 
     run vagga _run repo-with-suite banner Wonderful
-    printf "%s\n" "${lines[@]}"
     [[ $output = "#     #"* ]]
 }
 
 @test "ubuntu trusty: faketime" {
     run vagga _build faketime
-    printf "%s\n" "${lines[@]}"
     [[ $output != *"shm_open:"* ]]
 }

--- a/tests/ubuntu_release.bats
+++ b/tests/ubuntu_release.bats
@@ -10,47 +10,39 @@ setup() {
 
 @test "Run echo command in ubuntu release" {
     run vagga echo-cmd hello
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = hello ]]
     run vagga echo-cmd world
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = world ]]
 }
 
 @test "Run echo shell in ubuntu release" {
     run vagga echo-shell
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = "" ]]
     run vagga echo-shell hello
-    printf "%s\n" "${lines[@]}"
     [[ $status = 122 ]]
     [[ $output =~ "Unexpected argument" ]]
 }
 
 @test "Run echo shell with arguments in ubuntu release" {
     run vagga echo-shell-arg
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = "" ]]
     run vagga echo-shell-arg hello
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $output = "hello" ]]
 }
 
 @test "Run absent command in ubuntu release" {
     run vagga test something
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 121 ]]
     [[ $output =~ 'Command "test" not found and is not an alias' ]]
 }
 
 @test "ubuntu_release: Run bc in xenial by url" {
     run vagga xenial-calc 17*11
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/xenial-url)
     echo "Container: $link"
     [[ $status -eq 0 ]]
@@ -60,7 +52,6 @@ setup() {
 
 @test "ubuntu_release: Run bc in ubuntu derived from release" {
     run vagga derived-calc 100*24
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "2400" ]]
     link=$(readlink .vagga/ubuntu-release-derive)
@@ -69,7 +60,6 @@ setup() {
 
 @test "Run trusty bc in ubuntu release" {
     run vagga trusty-calc 23*7+3
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "164" ]]
     link=$(readlink .vagga/trusty-calc)
@@ -78,21 +68,18 @@ setup() {
 
 @test "Test VAGGAENV_* vars in ubuntu release" {
     VAGGAENV_TESTVAR=testvalue run vagga _run ubuntu-release printenv TESTVAR
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ $output = testvalue ]]
 }
 
 @test "Test set env in ubuntu release" {
     run vagga --environ TESTVAR=1value1 _run ubuntu-release printenv TESTVAR
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ $output = 1value1 ]]
 }
 
 @test "Test propagate env in ubuntu release" {
     TESTVAR=2value2 run vagga --use-env TESTVAR _run ubuntu-release printenv TESTVAR
-    printf "%s\n" "${lines[@]}"
     [[ $status -eq 0 ]]
     [[ $output = 2value2 ]]
 }

--- a/tests/uidmap.bats
+++ b/tests/uidmap.bats
@@ -4,7 +4,6 @@ setup() {
 
 @test "uidmap: Too much uids" {
     run vagga _build too-much-uids
-    printf "%s\n" "${lines[@]}"
     echo "Status: $status"
     [[ $status = 121 ]]
     [[ $output =~ "Number of allowed subuids is too small" ]]
@@ -12,7 +11,6 @@ setup() {
 
 @test "uidmap: Too much gids" {
     run vagga _build too-much-gids
-    printf "%s\n" "${lines[@]}"
     echo "Status: $status"
     [[ $status = 121 ]]
     [[ $output =~ "Number of allowed subgids is too small" ]]
@@ -27,7 +25,6 @@ setup() {
     run su user -c "vagga --ignore-owner-check _clean"
     umount /etc/subuid
     umount /etc/passwd
-    printf "%s\n" "${lines[@]}"
     echo "Status: $status"
     [[ $status = 121 ]]
     [[ $output =~ "includes original id" ]]
@@ -42,7 +39,6 @@ setup() {
     run su user -c "vagga --ignore-owner-check _build too-much-uids"
     umount /etc/subgid
     umount /etc/passwd
-    printf "%s\n" "${lines[@]}"
     echo "Status: $status"
     [[ $status = 121 ]]
     [[ $output =~ "includes original id" ]]

--- a/tests/vcs.bats
+++ b/tests/vcs.bats
@@ -4,7 +4,6 @@ setup() {
 
 @test "vcs: urp from git checkout" {
     run vagga urp-git -Q key=val http://example.com
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
     link=$(readlink .vagga/git)
@@ -13,7 +12,6 @@ setup() {
 
 @test "vcs: install from git checkout" {
     run vagga urp-git-install -Q key=val http://example.com
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
     link=$(readlink .vagga/git-install)
@@ -31,11 +29,9 @@ setup() {
     git describe
 
     run vagga _build git-describe-no-file
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
 
     run vagga _build git-describe
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     link=$(readlink .vagga/git-describe)
     [[ $link = ".roots/git-describe.022317fb/root" ]]
@@ -47,7 +43,6 @@ setup() {
     git describe
 
     run vagga _build git-describe
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     new_link=$(readlink .vagga/git-describe)
     [[ $link != $new_link ]]
@@ -59,7 +54,6 @@ setup() {
     git describe
 
     run vagga _build git-describe-pattern
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ $(cat .vagga/git-describe-pattern/version.txt) = "v0.0.1-2-"* ]]
 }

--- a/tests/version.bats
+++ b/tests/version.bats
@@ -4,7 +4,6 @@ setup() {
 
 @test "version: Check minimum version" {
     run vagga run something
-    printf "%s\n" "${lines[@]}"
     [[ $status = 126 ]]
     [[ ${lines[0]} = *'Minimum Vagga Error: Please upgrade vagga to at least "9999.0.0"' ]]
     [[ ${lines[1]} = *'Validation Error: The tag UnknownCommand is not expected' ]]

--- a/tests/volumes.bats
+++ b/tests/volumes.bats
@@ -4,7 +4,6 @@ setup() {
 
 @test "volumes: !CacheDir mount cache" {
     run vagga cachedir-count-files
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "1" ]]
 
@@ -14,7 +13,6 @@ setup() {
 
 @test "volumes: !CacheDir mount cache ubuntu" {
     run vagga cachedir-ubuntu-count-files
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "1" ]]
 
@@ -29,20 +27,16 @@ setup() {
     fi
 
     run vagga _run cachedir-add-files touch /mnt/cache/test1
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
 
     run vagga _run cachedir-add-files ls -1 /mnt/cache
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "test1" ]]
 
     run vagga _run cachedir-add-files touch /mnt/cache/test2
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
 
     run vagga _run cachedir-add-files ls -1 /mnt/cache
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-2]} = "test1" ]]
     [[ ${lines[${#lines[@]}-1]} = "test2" ]]
@@ -53,14 +47,12 @@ setup() {
 
 @test "volumes: !CacheDir mount empty path should fail" {
     run vagga _run cachedir-mount-empty-path date
-    printf "%s\n" "${lines[@]}"
     [[ $status = 124 ]]
     [[ ${lines[${#lines[@]}-1]} = *'mount !CacheDir: path must not be empty' ]]
 }
 
 @test "volumes: !CacheDir mount absolute path should fail" {
     run vagga _run cachedir-mount-absolute-path date
-    printf "%s\n" "${lines[@]}"
     [[ $status = 124 ]]
     [[ ${lines[${#lines[@]}-1]} = *'mount !CacheDir "/cache": path must not be absolute' ]]
 }

--- a/tests/yarn.bats
+++ b/tests/yarn.bats
@@ -13,16 +13,13 @@ setup() {
 END
     # don't check bin installations, because recent yarn have them broken
     run vagga resolve .
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = /work ]]
     run vagga _build pkg
-    printf "%s\n" "${lines[@]}"
     link=$(readlink .vagga/pkg)
     [[ $link = ".roots/pkg.dfb332bf/root" ]]
 
     run vagga stat /usr/lib/node_modules/classnames
-    printf "%s\n" "${lines[@]}"
     [[ $status = 1 ]]
 
     cat <<END > package.json
@@ -37,7 +34,6 @@ END
 }
 END
     run vagga stat /usr/lib/node_modules/classnames
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-7]} = "  File: /usr/lib/node_modules/classnames" ]]
     link=$(readlink .vagga/pkg)
@@ -61,7 +57,6 @@ END
 }
 END
     run vagga version
-    printf "%s\n" "${lines[@]}"
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = "1.0.1" ]]
     link=$(readlink .vagga/version)


### PR DESCRIPTION
We do not need to print command's output explicitly as modern bats has some useful options: `--verbose-run`, `--show-output-of-passing-tests`, `--trace`