### PR TITLE
Use vagga on github CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,28 +20,34 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 500
-      - name: Install musl-tools
-        run: "sudo apt-get install musl-tools"
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          target: x86_64-unknown-linux-musl
-          default: true
+
+      - name: Install vagga
+        run: |
+          echo 'deb [arch=amd64 trusted=yes] https://ubuntu.zerogw.com vagga-testing main' | \
+            sudo tee /etc/apt/sources.list.d/vagga.list
+          sudo apt-get update
+          sudo apt-get install -y vagga
+
       - uses: Swatinem/rust-cache@v1
-      - name: Cache multiple paths
+
+      - name: Vagga tests cache
         uses: actions/cache@v2
         with:
           path: |
             tmp/cache
           key: vagga-cache-v1
-      - run: |
-          make release  # slower build, faster tests
+
+      - name: Build and run tests
+        env:
+          UBUNTU_MIRROR: http://mirrors.us.kernel.org/ubuntu/
+        run: |
+          export VAGGA_SETTINGS="
+            cache-dir: ${GITHUB_WORKSPACE}/tmp/cache
+            external-volumes:
+              cargo: ${HOME}/.cargo"
+          vagga make-release-ci
           ./vagga -eUBUNTU_MIRROR test \
-            -j 8 \
+            -j 4 \
             --no-parallelize-within-files \
             --verbose-run \
             tests
-        env:
-          UBUNTU_MIRROR: http://mirrors.us.kernel.org/ubuntu/
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+    env:
+      VAGGA_CACHE: ~/.vagga/.cache
+      UBUNTU_MIRROR: http://mirrors.us.kernel.org/ubuntu/
     steps:
       - uses: actions/checkout@v2
         with:
@@ -28,25 +31,47 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y vagga
 
-      - uses: Swatinem/rust-cache@v1
+      - name: Prepare variables
+        run: |
+          echo "VAGGA_CACHE_HASH=$(vagga _version_hash --short rust-musl)" >> $GITHUB_ENV
+          echo "VAGGA_CACHE_DIR=${VAGGA_CACHE/#\~/$HOME}" >> $GITHUB_ENV
 
-      - name: Vagga tests cache
+      - name: Vagga settings
+        run: |
+          set -eux
+          echo "\
+          cache-dir: ${VAGGA_CACHE}
+          ubuntu-mirror: ${UBUNTU_MIRROR}
+          " > ~/.vagga.yaml
+
+          mkdir -p ${VAGGA_CACHE_DIR}
+
+      - name: Vagga cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ env.VAGGA_CACHE }}
+            !${{ env.VAGGA_CACHE }}/cargo/registry/src
+          key: vagga-v1-${{ runner.os }}-${{ env.VAGGA_CACHE_HASH }}
+
+      - name: Build cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            target
+          key: build-v1-${{ runner.os }}-${{ env.VAGGA_CACHE_HASH }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Tests cache
         uses: actions/cache@v2
         with:
           path: |
             tmp/cache
-          key: vagga-cache-v1
+          key: tests-v1-${{ runner.os }}
 
       - name: Build and run tests
-        env:
-          UBUNTU_MIRROR: http://mirrors.us.kernel.org/ubuntu/
         run: |
-          export VAGGA_SETTINGS="
-            cache-dir: ${GITHUB_WORKSPACE}/tmp/cache
-            external-volumes:
-              cargo: ${HOME}/.cargo"
-          echo "$VAGGA_SETTINGS"
-          vagga make-release-ci
+          set -eux
+          vagga make-release
           ./vagga -eUBUNTU_MIRROR test \
             -j 4 \
             --no-parallelize-within-files \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,7 @@ jobs:
             cache-dir: ${GITHUB_WORKSPACE}/tmp/cache
             external-volumes:
               cargo: ${HOME}/.cargo"
+          echo "$VAGGA_SETTINGS"
           vagga make-release-ci
           ./vagga -eUBUNTU_MIRROR test \
             -j 4 \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,9 @@ jobs:
             target
           key: build-v1-${{ runner.os }}-${{ env.VAGGA_CACHE_HASH }}-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Build
+        run: vagga make-release
+
       - name: Tests cache
         uses: actions/cache@v2
         with:
@@ -68,10 +71,8 @@ jobs:
             tmp/cache
           key: tests-v1-${{ runner.os }}
 
-      - name: Build and run tests
+      - name: Run tests
         run: |
-          set -eux
-          vagga make-release
           ./vagga -eUBUNTU_MIRROR test \
             -j 4 \
             --no-parallelize-within-files \

--- a/docs/build_commands.rst
+++ b/docs/build_commands.rst
@@ -341,7 +341,7 @@ it's usually perfectly okay if you only use node to build static scripts.
 The following ``npm`` features are supported:
 
 * Specify ``package@version`` to install specific version **(recommended)**
-* Use ``git://`` url for the package. In this case git will be installed for
+* Use ``git+https://`` url for the package. In this case git will be installed for
   the duration of the build automatically
 * Bare ``package_name`` (should be used only for one-off environments)
 

--- a/docs/build_steps.rst
+++ b/docs/build_steps.rst
@@ -551,7 +551,7 @@ Generic Commands
         - !Alpine v3.5
         - !Install [python3]
         - !Git
-          url: git://github.com/tailhook/injections
+          url: https://github.com/tailhook/injections.git
           path: /usr/lib/python3.5/site-packages/injections
 
    (the example above is actually a bad idea, many python packages will work
@@ -588,7 +588,7 @@ Generic Commands
         - !Alpine v3.5
         - !Install [python, py-setuptools]
         - !GitInstall
-          url: git://github.com/tailhook/injections
+          url: https://github.com/tailhook/injections.git
           script: python setup.py install
 
    Options:

--- a/examples/rethinkdb/vagga.yaml
+++ b/examples/rethinkdb/vagga.yaml
@@ -25,7 +25,7 @@ containers:
     - !Install
       - python          # for node-gyp
       - netcat-openbsd  # to check when rethinkdb is ready
-    - !NpmInstall [git://github.com/rethinkdb/rethinkdb-example-nodejs-chat.git]
+    - !NpmInstall [https://github.com/rethinkdb/rethinkdb-example-nodejs-chat.git]
 
 commands:
 

--- a/src/builder/commands/npm.rs
+++ b/src/builder/commands/npm.rs
@@ -168,6 +168,9 @@ pub fn parse_feature(info: &str, features: &mut Vec<packages::Package>) {
     // a version number for NpmDependencies. That's how npm works.
     if info[..].starts_with("git://") {
         features.push(packages::Git);
+    } else if info[..].starts_with("git+https://") {
+        features.push(packages::Git);
+        features.push(packages::Https);
     } // TODO(tailhook) implement whole a lot of other npm version kinds
 }
 

--- a/tests/npm.bats
+++ b/tests/npm.bats
@@ -39,7 +39,7 @@ setup() {
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = /work ]]
     link=$(readlink .vagga/git)
-    [[ $link = ".roots/git.8b42a947/root" ]]
+    [[ $link = ".roots/git.08dbe730/root" ]]
 }
 
 @test "npm: ubuntu git" {
@@ -47,7 +47,7 @@ setup() {
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = /work ]]
     link=$(readlink .vagga/git-ubuntu)
-    [[ $link = ".roots/git-ubuntu.035d58ac/root" ]]
+    [[ $link = ".roots/git-ubuntu.c90283eb/root" ]]
 }
 
 @test "npm: alpine git" {
@@ -55,7 +55,7 @@ setup() {
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = /work ]]
     link=$(readlink .vagga/git-alpine)
-    [[ $link = ".roots/git-alpine.0445ebc1/root" ]]
+    [[ $link = ".roots/git-alpine.25ca09cf/root" ]]
 }
 
 @test "npm: NpmDependencies" {

--- a/tests/npm/vagga.yaml
+++ b/tests/npm/vagga.yaml
@@ -21,17 +21,17 @@ containers:
 
   git:
     setup:
-    - !NpmInstall ["git://github.com/Witcher42/resolve-cli"]
+    - !NpmInstall ["git+https://github.com/Witcher42/resolve-cli"]
 
   git-ubuntu:
     setup:
     - !Ubuntu trusty
-    - !NpmInstall ["git://github.com/Witcher42/resolve-cli"]
+    - !NpmInstall ["git+https://github.com/Witcher42/resolve-cli"]
 
   git-alpine:
     setup:
     - !Alpine v3.9
-    - !NpmInstall ["git://github.com/Witcher42/resolve-cli"]
+    - !NpmInstall ["git+https://github.com/Witcher42/resolve-cli"]
 
   npm-deps:
     setup:

--- a/tests/pip.bats
+++ b/tests/pip.bats
@@ -23,7 +23,7 @@ setup() {
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
     link=$(readlink .vagga/py2-git-ubuntu)
-    [[ $link = ".roots/py2-git-ubuntu.3bfa83a6/root" ]]
+    [[ $link = ".roots/py2-git-ubuntu.a72f0333/root" ]]
 }
 
 @test "py2: alpine git" {
@@ -31,7 +31,7 @@ setup() {
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
     link=$(readlink .vagga/py2-git-alpine)
-    [[ $link = ".roots/py2-git-alpine.4839be1d/root" ]]
+    [[ $link = ".roots/py2-git-alpine.c4c6d37f/root" ]]
 }
 
 @test "py3: ubuntu pkg" {
@@ -56,7 +56,7 @@ setup() {
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
     link=$(readlink .vagga/py3-git-ubuntu)
-    [[ $link = ".roots/py3-git-ubuntu.53dd180a/root" ]]
+    [[ $link = ".roots/py3-git-ubuntu.57f20675/root" ]]
 }
 
 @test "py2: ubuntu req.txt" {

--- a/tests/pip/vagga.yaml
+++ b/tests/pip/vagga.yaml
@@ -14,13 +14,13 @@ containers:
     setup:
     - !Ubuntu xenial
     - !Py2Install [appdirs, pyparsing, packaging, six, setuptools,
-                   "git+git://github.com/jdp/urp"]
+                   "git+https://github.com/jdp/urp"]
 
   py2-git-alpine:
     setup:
     - !Alpine v3.4
     - !Py2Install [appdirs, pyparsing, packaging, six, setuptools,
-                   "git+git://github.com/jdp/urp"]
+                   "git+https://github.com/jdp/urp"]
 
   py3-ubuntu:
     setup:
@@ -40,7 +40,7 @@ containers:
     setup:
     - !Ubuntu xenial
     - !Py3Install [appdirs, pyparsing, packaging, six, setuptools,
-                   "git+git://github.com/jdp/urp"]
+                   "git+https://github.com/jdp/urp"]
 
   py2req-ubuntu:
     setup:

--- a/tests/vcs.bats
+++ b/tests/vcs.bats
@@ -7,7 +7,7 @@ setup() {
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
     link=$(readlink .vagga/git)
-    [[ $link = ".roots/git.71287cc7/root" ]]
+    [[ $link = ".roots/git.b00b84a7/root" ]]
 }
 
 @test "vcs: install from git checkout" {
@@ -15,7 +15,7 @@ setup() {
     [[ $status = 0 ]]
     [[ ${lines[${#lines[@]}-1]} = http://example.com?key=val ]]
     link=$(readlink .vagga/git-install)
-    [[ $link = ".roots/git-install.4e1d802a/root" ]]
+    [[ $link = ".roots/git-install.73d8492e/root" ]]
 }
 
 @test "vcs: git describe" {

--- a/tests/vcs/vagga.yaml
+++ b/tests/vcs/vagga.yaml
@@ -4,7 +4,7 @@ containers:
     - !Alpine v3.4
     - !Install [python]
     - !Git
-      url: git://github.com/jdp/urp
+      url: https://github.com/jdp/urp.git
       path: /usr/share/urp
 
   git-install:
@@ -12,7 +12,7 @@ containers:
     - !Alpine v3.4
     - !Install [python, py-setuptools]
     - !GitInstall
-      url: git://github.com/jdp/urp
+      url: https://github.com/jdp/urp.git
       script: python setup.py install
 
   git-describe:

--- a/vagga.yaml
+++ b/vagga.yaml
@@ -11,7 +11,6 @@ containers:
     environ: &rustenv
       LD_LIBRARY_PATH: /musl/lib/rustlib/x86_64-unknown-linux-musl/lib
       PATH: /musl/bin:/usr/local/bin:/usr/bin:/bin
-      HOME: /work/target
     setup:
     - !Ubuntu focal
     - !UbuntuUniverse
@@ -34,13 +33,14 @@ containers:
       url: "https://github.com/tailhook/bulk/releases/download/v0.4.9/bulk-v0.4.9.tar.gz"
       sha256: 23471a9986274bb4b7098c03e2eb7e1204171869b72c45385fcee1c64db2d111
       path: /
+    - !EnsureDir /root/.cargo
 
     # For packaging
     - !Install [make, checkinstall, git, uidmap, wget, gcc, libc6-dev, ca-certificates]
+    volumes:
+      /root/.cargo: !CacheDir cargo
 
   musleabihf:
-    environ:
-      HOME: /work/target
     setup:
     - !Ubuntu focal
     - !UbuntuUniverse
@@ -64,6 +64,9 @@ containers:
       url: "https://static.rust-lang.org/dist/rust-std-1.57.0-arm-unknown-linux-musleabihf.tar.gz"
       script: "./install.sh --prefix=/usr \
                --components=rust-std-arm-unknown-linux-musleabihf"
+    - !EnsureDir /root/.cargo
+    volumes:
+      /root/.cargo: !CacheDir cargo
 
   testbase:
     setup:
@@ -74,9 +77,9 @@ containers:
     - !Sh |
         set -ex
         cd /tmp
-        git clone --depth=1 https://github.com/bats-core/bats-core.git
-        git clone --depth=1 https://github.com/bats-core/bats-support.git /bats/bats-support
-        git clone --depth=1 https://github.com/bats-core/bats-assert.git /bats/bats-assert
+        git clone --depth=1 https://github.com/bats-core/bats-core
+        git clone --depth=1 https://github.com/bats-core/bats-support /bats/bats-support
+        git clone --depth=1 https://github.com/bats-core/bats-assert /bats/bats-assert
         cd bats-core
         ./install.sh /usr
 
@@ -131,18 +134,6 @@ commands:
     description: Build vagga for tests
     container: rust-musl
     run: [make, build-test]
-
-  make-release-ci: !Command
-    description: Build vagga with optimizations
-    prerequisites: [_mk-cargo-dir]
-    container: rust-musl
-    volumes:
-      /work/target/.cargo: !BindRW /volumes/cargo
-    run: [make, release]
-
-  _mk-cargo-dir: !Command
-    container: rust-musl
-    run: mkdir -p target/.cargo
 
   make-arm: !Command
     description: Cross-compile vagga for arm

--- a/vagga.yaml
+++ b/vagga.yaml
@@ -132,6 +132,18 @@ commands:
     container: rust-musl
     run: [make, build-test]
 
+  make-release-ci: !Command
+    description: Build vagga with optimizations
+    prerequisites: [_mk-cargo-dir]
+    container: rust-musl
+    volumes:
+      /work/target/.cargo: !BindRW /volumes/cargo
+    run: [make, release]
+
+  _mk-cargo-dir: !Command
+    container: rust-musl
+    run: mkdir -p target/.cargo
+
   make-arm: !Command
     description: Cross-compile vagga for arm
     container: musleabihf

--- a/vagga.yaml
+++ b/vagga.yaml
@@ -70,13 +70,13 @@ containers:
     - !Ubuntu focal
     - !UbuntuUniverse
     - !BuildDeps [wget]
-    - !Install [make, curl, zip, file, git, parallel]
+    - !Install [make, curl, zip, file, git, ca-certificates, parallel]
     - !Sh |
         set -ex
         cd /tmp
-        git clone git://github.com/bats-core/bats-core
-        git clone git://github.com/bats-core/bats-support.git /bats/bats-support
-        git clone git://github.com/bats-core/bats-assert.git /bats/bats-assert
+        git clone --depth=1 https://github.com/bats-core/bats-core.git
+        git clone --depth=1 https://github.com/bats-core/bats-support.git /bats/bats-support
+        git clone --depth=1 https://github.com/bats-core/bats-assert.git /bats/bats-assert
         cd bats-core
         ./install.sh /usr
 


### PR DESCRIPTION
Tested cargo and vagga caches inside my fork: https://github.com/anti-social/vagga/runs/4776366943

We could add `vagga _version_hash rust-musl` to the caches keys. What do you think?
